### PR TITLE
docs: impose le français pour toutes les PR

### DIFF
--- a/.ai/commands/github/code-pr-create.md
+++ b/.ai/commands/github/code-pr-create.md
@@ -3,7 +3,7 @@ allowed-tools: Bash(git :*), Bash(gh :*)
 description: Create and push PR with auto-generated title and description
 ---
 
-You are a PR automation tool. Create pull requests with concise, meaningful descriptions.
+You are a PR automation tool. Create pull requests with concise, meaningful descriptions **IN FRENCH**.
 
 ## Workflow
 
@@ -11,30 +11,48 @@ You are a PR automation tool. Create pull requests with concise, meaningful desc
 2. **Push**: `git push -u origin HEAD` to ensure remote tracking
 3. **Analyze**: `git diff origin/main...HEAD --stat` to understand changes
 4. **Generate**: Create PR with:
-   - Title: One-line summary (max 72 chars)
-   - Body: Bullet points of key changes
+   - Title: One-line summary (max 72 chars) **IN FRENCH**
+   - Body: Bullet points of key changes **IN FRENCH**
 5. **Submit**: `gh pr create --title "..." --body "..."`
 6. **Return**: Display PR URL
 
 ## PR Format
 
-```markdown
-## Summary
-• [Main change or feature]
-• [Secondary changes]
-• [Any fixes included]
+**CRITICAL**: All PR content MUST be in French.
 
-## Type
-[feat/fix/refactor/docs/chore]
+```markdown
+## Résumé
+• [Changement principal ou fonctionnalité]
+• [Changements secondaires]
+• [Corrections incluses]
 ```
 
 ## Execution Rules
 
+- **MANDATORY**: Write ALL PR content in French
 - NO verbose descriptions
 - NO "Generated with" signatures
 - Auto-detect base branch (main/master/develop)
 - Use HEREDOC for multi-line body
 - If PR exists, return existing URL
+
+## Examples
+
+**Good (French)** ✅:
+```markdown
+## Résumé
+• Ajout de l'authentification par API token
+• Mise à jour des tests de sécurité
+• Documentation des endpoints API
+```
+
+**Bad (English)** ❌:
+```markdown
+## Summary
+• Added API token authentication
+• Updated security tests
+• Documented API endpoints
+```
 
 ## Post-PR Validation
 
@@ -48,4 +66,4 @@ This runs the full CI suite locally to validate the pushed code.
 
 ## Priority
 
-Clarity > Completeness. Keep PRs scannable and actionable.
+Clarity > Completeness. Keep PRs scannable and actionable. **Always in French.**


### PR DESCRIPTION
## Résumé

• Ajoute l'exigence obligatoire d'écrire les messages de PR en français
• Met à jour la documentation de la commande code-pr-create

## Changements

### 📝 Documentation

**`.ai/commands/github/code-pr-create.md`**
- Ajout de "**IN FRENCH**" dans toutes les sections du workflow
- Format de PR changé : Summary → Résumé
- Section d'exemples ajoutée : bon (français) vs mauvais (anglais)
- Règle d'exécution : écrire TOUT le contenu de PR en français

## Impact

- **Agents IA** : Doivent écrire toutes les PR en français
- **Développeurs** : Rappel de la convention du projet
- **Consistance** : Documentation et PRs dans la même langue (français)

## Lié

- Fait partie des conventions de documentation du projet