### PR TITLE
Ajout des templates d'issues pour le workflow Shape-Up

### DIFF
--- a/.github/ISSUE_TEMPLATE/project-pitch.yml
+++ b/.github/ISSUE_TEMPLATE/project-pitch.yml
@@ -1,0 +1,88 @@
+name: 🎯 Project Pitch
+description: Créer un pitch de projet pour le Shape-Up
+title: "[PROJECT] "
+labels: ["project", "needs-shaping"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        ## 🎯 Pitch de Projet Shape-Up
+        Un projet est une initiative qui sera façonnée, puis potentiellement sélectionnée lors du betting.
+        Une fois sélectionné, il sera décomposé en plusieurs tâches pour le cycle.
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: 🔴 Problème
+      description: Quel problème résout-on ? Pourquoi est-ce important ?
+      placeholder: |
+        Décrivez le problème ou l'opportunité.
+        Exemple : "Les utilisateurs ne peuvent pas voir l'historique de leurs souscriptions..."
+    validations:
+      required: true
+
+  - type: dropdown
+    id: appetite
+    attributes:
+      label: ⏱️ Appétit
+      description: Combien de temps sommes-nous prêts à investir ?
+      options:
+        - "1 semaine"
+        - "2 semaines"
+        - "3 semaines"
+        - "4 semaines"
+        - "5 semaines"
+        - "6 semaines (cycle complet)"
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: 💡 Solution proposée
+      description: Approche envisagée (pas besoin de détails techniques à ce stade)
+      placeholder: |
+        Décrivez en quelques phrases l'approche proposée.
+        Restez au niveau conceptuel, pas d'implémentation détaillée.
+    validations:
+      required: true
+
+  - type: textarea
+    id: rabbit-holes
+    attributes:
+      label: 🐰 Rabbit Holes (pièges à éviter)
+      description: Quels sont les risques de complexité excessive ?
+      placeholder: |
+        - Ne pas essayer de migrer toute la base de données
+        - Éviter de refactoriser tout le module en même temps
+        - ...
+
+  - type: textarea
+    id: no-gos
+    attributes:
+      label: 🚫 No-Gos (hors scope)
+      description: Ce qu'on ne fera PAS dans ce projet
+      placeholder: |
+        - Pas de notifications temps réel
+        - Pas de support mobile dans cette version
+        - ...
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: 🎯 Domaine technique
+      description: Quel domaine technique principal ?
+      multiple: true
+      options:
+        - Backend
+        - Frontend
+        - API
+        - Infrastructure
+        - Sécurité
+        - Base de données
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: 📝 Notes additionnelles
+      description: Autres informations utiles

--- a/.github/ISSUE_TEMPLATE/task.yml
+++ b/.github/ISSUE_TEMPLATE/task.yml
@@ -1,0 +1,94 @@
+name: ✅ Task
+description: Tâche de cycle ou de cooldown
+title: ""
+labels: ["task"]
+body:
+  - type: dropdown
+    id: type
+    attributes:
+      label: Type de tâche
+      description: S'agit-il d'une tâche de cycle ou de cooldown ?
+      options:
+        - "📐 Task de cycle (issue d'un projet)"
+        - "🐛 Bug (cooldown)"
+        - "⚙️ Dette technique (cooldown)"
+        - "🔬 Exploration (cooldown)"
+    validations:
+      required: true
+
+  - type: input
+    id: parent
+    attributes:
+      label: Projet parent
+      description: "Si tâche de cycle, lien vers le projet parent (ex: #123)"
+      placeholder: "#123"
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: Que faut-il faire ?
+      placeholder: |
+        Pour une tâche de cycle : décrivez l'implémentation concrète
+        Pour un bug : comment le reproduire ?
+        Pour une dette : quel est le problème actuel ?
+        Pour une exploration : qu'est-ce qu'on veut découvrir ?
+    validations:
+      required: true
+
+  - type: dropdown
+    id: cycle
+    attributes:
+      label: Cycle / Cooldown
+      description: Quand cette tâche sera-t-elle faite ?
+      options:
+        - "Cycle 1"
+        - "Cycle 2"
+        - "Cycle 3"
+        - "Cooldown"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: estimation
+    attributes:
+      label: Estimation
+      description: Temps estimé
+      options:
+        - "< 1 jour"
+        - "1-2 jours"
+        - "3-5 jours"
+        - "1 semaine"
+        - "2 semaines"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: scope
+    attributes:
+      label: Domaine technique
+      description: Quel domaine ?
+      options:
+        - Backend
+        - Frontend
+        - API
+        - Infrastructure
+        - Sécurité
+        - Tests
+        - Documentation
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Critères d'acceptation (optionnel)
+      description: Comment saura-t-on que c'est terminé ?
+      placeholder: |
+        - [ ] Le endpoint /api/xxx retourne les bonnes données
+        - [ ] Les tests unitaires passent
+        - [ ] La documentation est à jour
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes additionnelles
+      description: Dépendances, contexte, liens utiles


### PR DESCRIPTION
## Résumé

Cette PR ajoute des templates d'issues GitHub pour supporter la méthodologie de travail Shape-Up.

## Changements

- **Template Project Pitch** : Template structuré pour façonner de nouveaux projets avec :
  - Définition du problème et appétit (temps estimé)
  - Approche de solution proposée
  - Rabbit holes (pièges à éviter)
  - No-gos (ce qui est hors scope)
  
- **Template Task** : Template unifié pour les tâches de cycle et les items de cooldown :
  - Supporte les tâches de cycle (liées à un projet parent)
  - Supporte les items de cooldown (bugs, dette technique, exploration)
  - Inclut estimation et critères d'acceptation

## Utilisation

Ces templates seront disponibles lors de la création de nouvelles issues sur GitHub, aidant à structurer le travail selon les cycles de 6 semaines avec périodes de cooldown de 2 semaines du Shape-Up.

Les projets sont façonnés avec le template Project Pitch, puis décomposés en Tasks pendant les cycles.