### PR TITLE
chore(renovate): mettre en place Renovate sur le portail V2

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,6 +1,4 @@
-# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=3.4.7
-FROM ghcr.io/rails/devcontainer/images/ruby:$RUBY_VERSION
+FROM ghcr.io/rails/devcontainer/images/ruby:4.0.5@sha256:5623e7d5e4c40db70c2dc527381a6e3c4b3f750ed60eee79409a163bc58c259c
 
 # Ensure binding is always 0.0.0.0
 # Binds the server to all IP addresses of the container, so it can be accessed from outside the container.

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,9 +7,7 @@
 
 # For a containerized dev environment, see Dev Containers: https://guides.rubyonrails.org/getting_started_with_devcontainer.html
 
-# Make sure RUBY_VERSION matches the Ruby version in .ruby-version
-ARG RUBY_VERSION=3.4.7
-FROM docker.io/library/ruby:$RUBY_VERSION-slim AS base
+FROM docker.io/library/ruby:4.0.5-slim@sha256:1d0c7f972f28c127b37a9ef24404c1fd26549919bfbe8d360b506e2e799ea13b AS base
 
 # Rails app lives here
 WORKDIR /rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -100,7 +100,7 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crass (1.0.6)
     cucumber (10.2.0)

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,28 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "dockerfile": {
+    "fileMatch": ["(^|/)Containerfile$", "(^|/)Dockerfile$", "(^|/)\\.devcontainer/Dockerfile$"]
+  },
+  "mise": {
+    "fileMatch": ["(^|/)mise\\.toml$", "(^|/)\\.mise\\.toml$"]
+  },
+  "customManagers": [
+    {
+      "customType": "regex",
+      "fileMatch": ["(^|/)\\.github/workflows/[^/]+\\.ya?ml$"],
+      "matchStrings": ["ruby-version:\\s*[\"']?(?<currentValue>[\\d.]+)"],
+      "depNameTemplate": "ruby",
+      "datasourceTemplate": "ruby-version"
+    }
+  ],
+  "packageRules": [
+    {
+      "matchPackageNames": [
+        "ruby",
+        "docker.io/library/ruby",
+        "ghcr.io/rails/devcontainer/images/ruby"
+      ],
+      "groupName": "Ruby version"
+    }
+  ]
+}


### PR DESCRIPTION
## Contexte

Le portail V2 n'avait aucune gestion automatisée de ses dépendances. On
met en place Renovate, exécuté par le job dédié du dépôt `renovate-ci`.
Cf. ticket de suivi interne.

## Changements

- Ajout de `renovate.json` : managers `dockerfile` et `mise`, un
  `customManager` pour `ruby-version` dans les workflows GitHub Actions,
  et regroupement des bumps Ruby en une seule PR (style `admin-portal`).
- Épinglage des images Docker par tag + digest `sha256`
  (`Dockerfile`, `.devcontainer/Dockerfile`) et alignement de la version
  Ruby sur 4.0.5 (elles étaient restées à 3.4.7 alors que `mise` et la CI
  ciblent 4.0.5). Digests vérifiés auprès des registries docker.io et ghcr.io.

## Tests

- [x] Étapes statiques de `bin/ci` : standardrb, brakeman, importmap — vertes
- [ ] `bin/ci` complet à rejouer sur un environnement avec PostgreSQL

## Prérequis

Cette configuration ne devient active qu'une fois le job `renovate-github`
ajouté côté `renovate-ci` (plateforme GitHub + token d'écriture dédié).
