### PR TITLE
chore(devcontainer): passer postgres de 16.1 à 18

### DIFF
--- a/.devcontainer/compose.yaml
+++ b/.devcontainer/compose.yaml
@@ -21,7 +21,7 @@ services:
     - postgres
 
   postgres:
-    image: postgres:16.1
+    image: postgres:18
     restart: unless-stopped
     networks:
     - default

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,6 +2,8 @@ name: CI
 
 on:
   push:
+    branches:
+      - main
   pull_request:
     branches:
       - main
@@ -10,10 +12,6 @@ jobs:
   ci:
     name: CI complète
     runs-on: ubuntu-latest
-    if: >-
-      github.event_name == 'push' ||
-      github.event.pull_request.head.repo.full_name == github.repository
-
     services:
       postgres:
         image: postgres:18


### PR DESCRIPTION
La CI utilise déjà postgres:18 — aligne l'environnement de dev local pour éviter toute divergence de comportement.