### PR TITLE
chore(monitoring): intégrer Sentry pour le suivi des erreurs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,6 +36,10 @@ gem "aasm"
 # Business logic interactors [https://github.com/collectiveidea/interactor]
 gem "interactor"
 
+# Error monitoring [https://github.com/getsentry/sentry-ruby]
+gem "sentry-ruby"
+gem "sentry-rails"
+
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[windows jruby]
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -354,6 +354,13 @@ GEM
       rubocop-ast (>= 1.47.1, < 2.0)
     ruby-progressbar (1.13.0)
     securerandom (0.4.1)
+    sentry-rails (6.6.2)
+      railties (>= 5.2.0)
+      sentry-ruby (~> 6.6.2)
+    sentry-ruby (6.6.2)
+      bigdecimal
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      logger
     shoulda-matchers (8.0.1)
       activesupport (>= 7.2)
     simplecov (0.22.0)
@@ -458,6 +465,8 @@ DEPENDENCIES
   puma (>= 5.0)
   rails (~> 8.1.1)
   rspec-rails
+  sentry-rails
+  sentry-ruby
   shoulda-matchers
   simplecov
   solid_cable

--- a/config/initializers/sentry.rb
+++ b/config/initializers/sentry.rb
@@ -1,0 +1,7 @@
+if ENV["SENTRY_DSN"].present?
+  Sentry.init do |config|
+    config.dsn = ENV["SENTRY_DSN"]
+    config.breadcrumbs_logger = [:active_support_logger, :http_logger]
+    config.send_default_pii = false
+  end
+end


### PR DESCRIPTION
Ajoute sentry-ruby + sentry-rails. L'initializer ne s'active que si SENTRY_DSN est présent — Sentry reste inerte en local et en test.

send_default_pii=false pour s'assurer que les params passent par filtered_parameters (respecte la denylist filter_parameter_logging.rb) et non read_data_from qui contourne le filtrage.