### PR TITLE
chore(ci): déclencher la CI chaque nuit à 5h UTC

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,6 +7,8 @@ on:
   pull_request:
     branches:
       - main
+  schedule:
+    - cron: "0 5 * * *"
 
 jobs:
   ci:


### PR DESCRIPTION
Ajoute un trigger schedule pour détecter tôt les régressions introduites par des dépendances mises à jour hors des PR.