### PR TITLE
feat(securite): gérer force_ssl côté app et activer une CSP minimale

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -423,7 +423,7 @@ GEM
       actionview (>= 8.0.0)
       bindex (>= 0.4.0)
       railties (>= 8.0.0)
-    websocket-driver (0.8.1)
+    websocket-driver (0.8.2)
       base64
       websocket-extensions (>= 0.1.0)
     websocket-extensions (0.1.5)

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -24,14 +24,19 @@ Rails.application.configure do
   # Store uploaded files on the local file system (see config/storage.yml for options).
   config.active_storage.service = :local
 
-  # Assume all access to the app is happening through a SSL-terminating reverse proxy.
+  # HTTPS géré côté applicatif (décision #509, prise avec l'infra qui s'alignera
+  # ensuite). Le TLS est terminé par le reverse-proxy d'infra, qui transmet du
+  # HTTP en clair au conteneur.
+  # - assume_ssl : on considère toute requête comme arrivée en HTTPS. La
+  #   redirection interne de force_ssl ne se déclenche donc jamais → aucune boucle
+  #   de redirection possible, sans dépendre de X-Forwarded-Proto (dont on ne
+  #   maîtrise pas la traversée proxy + Thruster).
+  # - force_ssl : l'app devient source de vérité pour HSTS + flag Secure du cookie.
   config.assume_ssl = true
-
-  # Force all access to the app over SSL, use Strict-Transport-Security, and use secure cookies.
   config.force_ssl = true
 
-  # Skip http-to-https redirect for the default health check endpoint.
-  # config.ssl_options = { redirect: { exclude: ->(request) { request.path == "/up" } } }
+  # Pas de config.ssl_options ici : assume_ssl neutralise la redirection de
+  # force_ssl, donc /up n'est jamais redirigé (l'exclusion serait inutile).
 
   # Log to STDOUT with the current request id as a default log tag.
   config.log_tags = [:request_id]

--- a/config/initializers/content_security_policy.rb
+++ b/config/initializers/content_security_policy.rb
@@ -1,29 +1,25 @@
 # Be sure to restart your server when you modify this file.
 
-# Define an application-wide content security policy.
-# See the Securing Rails Applications Guide for more information:
-# https://guides.rubyonrails.org/security.html#content-security-policy-header
+# Politique CSP minimale (defense-in-depth, ticket #509).
+# Dérivée du stack V2 (importmap + DSFR), pas recopiée du code V1 :
+# - script-src : 'self' + nonce → importmap-rails pose le nonce automatiquement
+#   sur ses balises ; pas de 'unsafe-inline' JS.
+# - style-src : 'unsafe-inline' SANS nonce → requis par les styles inline posés
+#   au runtime par DSFR (attributs style="" via JS). En CSP3, un nonce sur
+#   style-src désactiverait 'unsafe-inline' et casserait le rendu DSFR.
+Rails.application.configure do
+  config.content_security_policy do |policy|
+    policy.default_src :self
+    policy.object_src :none
+    policy.img_src :self, :data
+    policy.font_src :self, :data
+    policy.connect_src :self
+    policy.script_src :self
+    policy.style_src :self, :unsafe_inline
+  end
 
-# Rails.application.configure do
-#   config.content_security_policy do |policy|
-#     policy.default_src :self, :https
-#     policy.font_src    :self, :https, :data
-#     policy.img_src     :self, :https, :data
-#     policy.object_src  :none
-#     policy.script_src  :self, :https
-#     policy.style_src   :self, :https
-#     # Specify URI for violation reports
-#     # policy.report_uri "/csp-violation-report-endpoint"
-#   end
-#
-#   # Generate session nonces for permitted importmap, inline scripts, and inline styles.
-#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
-#   config.content_security_policy_nonce_directives = %w(script-src style-src)
-#
-#   # Automatically add `nonce` to `javascript_tag`, `javascript_include_tag`, and `stylesheet_link_tag`
-#   # if the corresponding directives are specified in `content_security_policy_nonce_directives`.
-#   # config.content_security_policy_nonce_auto = true
-#
-#   # Report violations without enforcing the policy.
-#   # config.content_security_policy_report_only = true
-# end
+  # Nonce aléatoire par requête (et non request.session.id) : V2 n'utilise pas
+  # de session, donc session.id serait nil → nonce vide → CSP inopérante.
+  config.content_security_policy_nonce_generator = ->(_request) { SecureRandom.base64(16) }
+  config.content_security_policy_nonce_directives = %w[script-src]
+end

--- a/spec/requests/security/content_security_policy_spec.rb
+++ b/spec/requests/security/content_security_policy_spec.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# La CSP minimale (defense-in-depth) est active dans tous les environnements via
+# config/initializers/content_security_policy.rb. On vérifie ici le contrat de la
+# politique sur une réponse HTML rendue (page d'accueil du portail).
+RSpec.describe "Content Security Policy", type: :request do
+  subject(:csp) { response.headers["Content-Security-Policy"] }
+
+  before { get "/" }
+
+  it "sets an enforcing Content-Security-Policy header" do
+    expect(response).to have_http_status(:success)
+    expect(csp).to be_present
+  end
+
+  it "locks the base policy to self and forbids plugins" do
+    expect(csp).to include("default-src 'self'")
+    expect(csp).to include("object-src 'none'")
+    expect(csp).to include("connect-src 'self'")
+    expect(csp).to include("img-src 'self' data:")
+    expect(csp).to include("font-src 'self' data:")
+  end
+
+  it "allows scripts only from self with a per-request nonce (importmap)" do
+    expect(csp).to match(/script-src 'self' 'nonce-[^']+'/)
+  end
+
+  it "allows inline styles required by the DSFR runtime (without a nonce)" do
+    expect(csp).to include("style-src 'self' 'unsafe-inline'")
+  end
+end


### PR DESCRIPTION
## Contexte

Le ticket suivi-projet #509 demande de gérer `force_ssl` et de revoir les garde-fous
de sécurité applicatifs. Décision (prise avec l'infra) : le HTTPS est géré **côté
applicatif** pour les apps Rails, l'infra s'alignant ensuite.

## Changements

- **`force_ssl` côté app** (`config/environments/production.rb`) : `assume_ssl` +
  `force_ssl` sont actés et documentés. `assume_ssl` fait considérer chaque requête
  comme HTTPS → la redirection de `force_ssl` ne se déclenche jamais (aucune boucle,
  `/up` intact, robuste à Thruster) ; l'app devient source de vérité pour HSTS + le
  flag `Secure` du cookie.
- **CSP minimale enforçante** (`config/initializers/content_security_policy.rb`,
  jusqu'ici 100 % commentée) : `default-src 'self'`, `object-src 'none'`,
  `script-src 'self'` + nonce aléatoire (importmap), `style-src 'self' 'unsafe-inline'`
  (styles inline runtime DSFR). Nonce aléatoire et non basé sur `session.id` : l'app
  n'utilise pas de session, un nonce vide casserait la CSP. Verrouillée par un request
  spec.

## Tests

- [x] Request spec CSP (`spec/requests/security/content_security_policy_spec.rb`)
- [x] `bin/ci` vert (StandardRB, bundler-audit, Brakeman, importmap, RSpec, E2E, Seeds)
- [ ] Vérification manuelle `force_ssl` (sur l'environnement déployé) :
  - `curl -sI https://<host>/` → présence de `Strict-Transport-Security`
  - `curl -sI http://<host>/up` → `200` sans redirection

## Coordination infra (à traiter côté déploiement / reverse-proxy)

L'app étant désormais source de vérité pour ces garde-fous, le reverse-proxy devrait
s'aligner :

1. **HSTS en double** — l'app pose son propre `Strict-Transport-Security` (défaut Rails
   `max-age=63072000; includeSubDomains`). Deux en-têtes STS = seul le premier est lu
   (RFC 6797). → retirer/aligner le HSTS côté proxy.
2. **`referrer-policy`** — si le proxy pose `no-referrer-when-downgrade` (plus faible
   que le défaut Rails `strict-origin-when-cross-origin`), à durcir.

## Refs

- suivi-projet #509
