### PR TITLE
fix(deps): charger strong_migrations dans tous les environnements

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -57,6 +57,12 @@ gem "solid_cache"
 gem "solid_queue"
 gem "solid_cable"
 
+# Catch unsafe database migrations [https://github.com/ankane/strong_migrations]
+# Chargée dans tous les environnements : l'entrypoint Docker joue db:prepare en
+# production, les checks doivent donc protéger aussi les migrations prod — et
+# l'initializer référence la constante à chaque boot, y compris en prod.
+gem "strong_migrations"
+
 # Reduces boot times through caching; required in config/boot.rb
 gem "bootsnap", require: false
 
@@ -72,9 +78,6 @@ group :development, :test do
 
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", require: false
-
-  # Catch unsafe database migrations [https://github.com/ankane/strong_migrations]
-  gem "strong_migrations"
 
   # Ruby style guide, linter, and formatter [https://github.com/standardrb/standard]
   gem "standard", require: false


### PR DESCRIPTION
## Contexte

`config/initializers/strong_migrations.rb` référence la constante
`StrongMigrations` au chargement (elle tourne à **chaque** boot Rails, tous
environnements confondus). Or la gem était déclarée dans le groupe
`:development, :test` du Gemfile → absente du bundle de production.

Résultat : en production, `Bundler.require` ne charge pas la gem →
`NameError: uninitialized constant StrongMigrations` au boot. Le conteneur ne
démarre donc jamais, d'autant que `bin/docker-entrypoint` lance
`./bin/rails db:prepare` au démarrage du serveur (les migrations tournent bien
en prod).

## Changement

- `gem "strong_migrations"` sort du groupe `:development, :test` et passe en
  dépendance principale (chargée dans tous les environnements).

## Pourquoi cette approche

Les migrations s'exécutant réellement en production (via `db:prepare` de
l'entrypoint), les garde-fous strong_migrations doivent y rester actifs.
Neutraliser l'initializer en prod (`return unless defined?`) aurait fait
booter l'app mais désactivé silencieusement les checks là où ils comptent le
plus. Charger la gem partout est aussi la configuration recommandée en amont.

## Tests

- [x] Boot production vérifié : `RAILS_ENV=production bin/rails runner` démarre
      désormais, `StrongMigrations` défini, initializer appliqué
      (`start_after` lu). Avant le fix : `NameError` au boot.
- [x] `bin/ci` vert : 174 exemples / 0 échec, couverture 98,0 %, brakeman +
      bundler-audit + importmap clean, Cucumber E2E + seeds OK.

_Pas de spec dédié : le bug est un crash de boot prod, non reproductible en env
`test` (la gem y était déjà présente). La garantie est la vérif de boot prod
ci-dessus ; un spec bootant un env prod complet serait lourd et disproportionné
pour un déplacement de gem d'une ligne._