### PR TITLE
fix(deps): corriger 4 advisories sur loofah et rails-html-sanitizer

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -202,7 +202,7 @@ GEM
     language_server-protocol (3.17.0.5)
     lint_roller (1.1.0)
     logger (1.7.0)
-    loofah (2.25.1)
+    loofah (2.25.2)
       crass (~> 1.0.2)
       nokogiri (>= 1.12.0)
     mail (2.9.0)
@@ -301,8 +301,8 @@ GEM
       activesupport (>= 5.0.0)
       minitest
       nokogiri (>= 1.6)
-    rails-html-sanitizer (1.7.0)
-      loofah (~> 2.25)
+    rails-html-sanitizer (1.7.1)
+      loofah (~> 2.25, >= 2.25.2)
       nokogiri (>= 1.15.7, != 1.16.7, != 1.16.6, != 1.16.5, != 1.16.4, != 1.16.3, != 1.16.2, != 1.16.1, != 1.16.0.rc1, != 1.16.0)
     rails_semantic_logger (5.0.0)
       rack


### PR DESCRIPTION
Contournements `javascript:` dans `allowed_uri?` et bypass de la restriction de référence locale sur `href` SVG (loofah 2.25.2), XSS possible selon la configuration (rails-html-sanitizer 1.7.1).

Update conservateur : dépendances transitives de Rails, aucune autre gem touchée.