### PR TITLE
chore(renovate): groupe la version Ruby sur depName et non packageName

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -13,20 +13,9 @@
       "/(^|/)\\.mise\\.toml$/"
     ]
   },
-  "customManagers": [
-    {
-      "customType": "regex",
-      "managerFilePatterns": [
-        "/(^|/)\\.github/workflows/[^/]+\\.ya?ml$/"
-      ],
-      "matchStrings": ["ruby-version:\\s*[\"']?(?<currentValue>[\\d.]+)"],
-      "depNameTemplate": "ruby",
-      "datasourceTemplate": "ruby-version"
-    }
-  ],
   "packageRules": [
     {
-      "matchPackageNames": [
+      "matchDepNames": [
         "ruby",
         "docker.io/library/ruby"
       ],


### PR DESCRIPTION
matchPackageNames ne compare que packageName, or le manager mise force
"ruby-version" pour l'outil ruby : .mise.toml échappait au groupe et
partait dans sa propre PR (#97). depName vaut "ruby" pour tous.

Retire aussi le customManager regex, redondant : le manager natif
github-actions détecte déjà ruby-version dans ruby/setup-ruby.
