### PR TITLE
Débloquer les connexions ProConnect et durcir le parcours d'authentification

### DIFF
--- a/app/controllers/portail/base_controller.rb
+++ b/app/controllers/portail/base_controller.rb
@@ -5,5 +5,29 @@ module Portail
     include Portail::Authentication
 
     layout "portail"
+
+    # Les pages du portail portent un jeton CSRF lié à la session, et cette session est
+    # renouvelée à chaque connexion, refus ou déconnexion. Ressorties du cache par le
+    # bouton « précédent », elles présenteraient un jeton périmé — le formulaire
+    # ProConnect échouerait en InvalidAuthenticityToken. `no-store` force le navigateur à
+    # redemander la page au lieu de la restituer.
+    before_action :do_not_cache
+
+    # Un onglet resté ouvert pendant qu'un autre renouvelle la session présente ensuite un
+    # jeton périmé — le cas typique étant deux onglets qu'on déconnecte l'un après l'autre.
+    # Aucun en-tête n'y peut rien : la page est déjà affichée. La requête reste rejetée,
+    # on ne relâche pas la protection ; on remplace seulement l'erreur brute par un
+    # rechargement.
+    rescue_from ActionController::InvalidAuthenticityToken, with: :reload_stale_page
+
+    private
+
+    def do_not_cache
+      response.headers["Cache-Control"] = "no-store"
+    end
+
+    def reload_stale_page
+      redirect_to root_path, alert: t("portail.errors.stale_page")
+    end
   end
 end

--- a/app/controllers/portail/sessions_controller.rb
+++ b/app/controllers/portail/sessions_controller.rb
@@ -2,6 +2,10 @@
 
 module Portail
   class SessionsController < Portail::BaseController
+    # Motifs qui ne portent aucun jugement sur l'agent : rien à lui expliquer sur son
+    # compte, la page d'échec générique suffit.
+    TECHNICAL_FAILURES = %i[invalid_token provider_unavailable sign_in_conflict].freeze
+
     def create
       result = Portail::Sessions::Create.call(
         id_token: auth_hash.credentials.id_token,
@@ -10,20 +14,53 @@ module Portail
         siret: auth_hash.extra.raw_info&.dig("siret")
       )
 
+      log_proconnect_exchange(result)
+
       if result.success?
         start_agent_session!(result.membership, auth_hash.credentials.id_token)
         redirect_to root_path, notice: t(".signed_in")
-      elsif result.error == :invalid_token
+      elsif TECHNICAL_FAILURES.include?(result.error)
         redirect_to auth_failure_path
       else
-        render_denied(result.error)
+        deny_access!(result.error)
       end
     end
 
+    # L'agent est authentifié chez ProConnect mais le portail lui refuse l'entrée. Sa
+    # session ProConnect reste ouverte : sans action de sa part, recliquer sur le bouton
+    # le réauthentifierait à l'identique, en boucle. On lui montre donc l'adresse qu'il
+    # vient d'utiliser, et un moyen de repartir sur un autre compte.
+    #
+    # La déconnexion n'est pas déclenchée d'office : elle le sortirait de ProConnect pour
+    # tous les services, pas seulement pour HubEE. C'est son choix, pas le nôtre.
+    #
+    # Une seule vue pour tous les motifs : seul le message change. Tout nouveau refus
+    # atterrit ici sans code supplémentaire — il lui suffit de ses deux clés de traduction.
+    def denied
+      # La liste des motifs valides, c'est celle des traductions : un cookie d'avant un
+      # renommage ne fait pas tomber la page, et rien n'est à tenir à jour ici.
+      return redirect_to root_path unless known_denial_reason?
+
+      @denial_reason = session[:denial_reason]
+      @authenticated_email = session[:denial_email]
+      # ProConnect muet, on montre quand même le motif du refus : seul le bouton de
+      # changement de compte disparaît, faute de pouvoir construire son URL.
+      @switch_account_url = begin
+        Portail::ProConnect::LogoutUrlBuilder.call(id_token: session[:denial_id_token])
+      rescue Portail::ProConnect::Discovery::Unavailable
+        nil
+      end
+      render :denied, status: :forbidden
+    end
+
+    # reset_session d'abord : la déconnexion du portail est acquise avant tout appel
+    # sortant. ProConnect injoignable ne doit jamais retenir un agent connecté.
     def destroy
       id_token = session[:proconnect_id_token]
       reset_session
       redirect_to Portail::ProConnect::LogoutUrlBuilder.call(id_token:), allow_other_host: true
+    rescue Portail::ProConnect::Discovery::Unavailable
+      redirect_to root_path, alert: t(".provider_unavailable")
     end
 
     def failure
@@ -36,23 +73,34 @@ module Portail
       request.env["omniauth.auth"]
     end
 
-    # L'agent est authentifié chez ProConnect mais le portail lui refuse l'entrée, pour
-    # un motif ou un autre. Sa session ProConnect reste ouverte : sans action de sa part,
-    # recliquer sur le bouton le réauthentifierait à l'identique, en boucle. On lui montre
-    # donc l'adresse qu'il vient d'utiliser, et un moyen de repartir sur un autre compte.
-    #
-    # La déconnexion n'est pas déclenchée d'office : elle le sortirait de ProConnect pour
-    # tous les services, pas seulement pour HubEE. C'est son choix, pas le nôtre.
-    #
-    # Une seule vue pour tous les motifs : seul le message change. Tout nouveau refus
-    # atterrit ici sans code supplémentaire — il lui suffit de ses deux clés de traduction.
-    def render_denied(reason)
-      @denial_reason = reason
-      @authenticated_email = auth_hash.info.email
-      @switch_account_url = Portail::ProConnect::LogoutUrlBuilder.call(
-        id_token: auth_hash.credentials.id_token
-      )
-      render :denied, status: :forbidden
+    def known_denial_reason?
+      session[:denial_reason].present? &&
+        I18n.exists?("portail.sessions.denied.#{session[:denial_reason]}.heading")
+    end
+
+    # Le motif transite par la session, pas par le flash : le flash se consomme à la
+    # première lecture, donc recharger la page de refus la viderait. reset_session d'abord,
+    # comme à l'ouverture d'une session — on s'apprête à y déposer une identité.
+    def deny_access!(reason)
+      reset_session
+      session[:denial_reason] = reason.to_s
+      session[:denial_email] = auth_hash.info.email
+      session[:denial_id_token] = auth_hash.credentials.id_token
+      redirect_to denied_path
+    end
+
+    # Donne à voir ce que ProConnect a renvoyé et la décision qu'on en tire. Hors production
+    # seulement : ce sont des données personnelles, et la piste d'audit relève d'un autre
+    # dispositif. Le jeton lui-même n'est jamais journalisé, seuls ses claims vérifiés.
+    def log_proconnect_exchange(result)
+      return unless Rails.env.local?
+
+      Rails.logger.info <<~LOG
+        [ProConnect] userinfo  : #{JSON.pretty_generate(auth_hash.extra.raw_info&.to_h || {})}
+        [ProConnect] id_token  : #{(result.claims || {}).inspect}
+        [ProConnect] siret reçu: #{auth_hash.extra.raw_info&.dig("siret").inspect}
+        [ProConnect] décision  : #{result.success? ? "entrée accordée (rattachement ##{result.membership.id})" : "refus (#{result.error})"}
+      LOG
     end
 
     # reset_session AVANT de poser l'identité : protection contre la session fixation.

--- a/app/helpers/portail/support_helper.rb
+++ b/app/helpers/portail/support_helper.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+module Portail
+  # Adresse publique du support, affichée partout où l'agent est bloqué. Elle vit ici
+  # plutôt que dans un contrôleur : c'est du contenu, pas du comportement.
+  module SupportHelper
+    SUPPORT_EMAIL = "support@hubee.numerique.gouv.fr"
+
+    def support_email = SUPPORT_EMAIL
+  end
+end

--- a/app/interactors/portail/sessions/create.rb
+++ b/app/interactors/portail/sessions/create.rb
@@ -5,7 +5,10 @@ module Portail
     class Create
       include Interactor::Organizer
 
-      organize VerifyIdToken, CheckAuthenticationLevel, FindAgent, FindMembership
+      # SyncAgentIdentity vient en dernier : rien n'est écrit tant que l'accès n'est
+      # pas acquis.
+      organize VerifyIdToken, CheckAuthenticationLevel, FindAgent, FindMembership,
+        SyncAgentIdentity
     end
   end
 end

--- a/app/interactors/portail/sessions/create/find_agent.rb
+++ b/app/interactors/portail/sessions/create/find_agent.rb
@@ -3,36 +3,25 @@
 module Portail
   module Sessions
     class Create
+      # Résout l'agent sans rien écrire — la fiche n'est alignée qu'une fois l'accès
+      # accordé, par SyncAgentIdentity. Une connexion ne crée JAMAIS de compte.
       class FindAgent
         include Interactor
 
-        # Une connexion ProConnect ne crée JAMAIS de compte : agent inconnu → échec,
-        # aucune écriture.
         def call
-          # Normalisée comme à l'écriture, sinon la recherche et la comparaison ci-dessous
-          # échoueraient sur une simple différence de casse.
+          # Normalisée comme à l'écriture : sinon une différence de casse suffirait à
+          # faire échouer la recherche puis la comparaison.
           email = Agent.normalize_value_for(:email, context.info[:email])
-          sub = context.claims[:sub]
 
-          # Le `sub` identifie l'agent une fois rattaché. L'adresse ne sert qu'au tout
-          # premier rattachement — agent enrôlé jamais connecté — et vient du jeton
-          # vérifié : la connaître ne suffit pas.
-          agent = Agent.find_by(provider_sub: sub) || Agent.find_by(email:)
+          # Le `sub` identifie l'agent une fois rattaché ; l'adresse ne sert qu'au tout
+          # premier rattachement, celui d'un agent enrôlé jamais connecté.
+          agent = Agent.find_by(provider_sub: context.claims[:sub]) || Agent.find_by(email:)
           context.fail!(error: :unknown_agent) if agent.nil?
 
-          # Rare ici : avec une organisation vérifiée, un changement d'adresse s'accompagne
-          # le plus souvent d'un nouveau compte, donc d'un nouveau `sub` — on atterrirait
-          # sur « inconnu ». Prévalence réelle incertaine : on bloque et on trace, quitte
-          # à réévaluer.
+          # Rare : changer d'adresse s'accompagne le plus souvent d'un nouveau compte,
+          # donc d'un nouveau `sub`. On bloque par prudence.
           context.fail!(error: :email_mismatch) if agent.email != email
 
-          agent.update!(
-            provider_sub: sub,
-            email:,
-            first_name: context.info[:first_name],
-            last_name: context.info[:last_name],
-            amr: context.claims[:amr]
-          )
           context.agent = agent
         end
       end

--- a/app/interactors/portail/sessions/create/sync_agent_identity.rb
+++ b/app/interactors/portail/sessions/create/sync_agent_identity.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+module Portail
+  module Sessions
+    class Create
+      # Dernière étape, une fois l'accès accordé : la fiche est alignée sur l'identité
+      # attestée par ProConnect, qui fait foi. Écrire plus tôt graverait une décision non
+      # rendue — une tentative refusée laisserait sa trace.
+      #
+      # Pas d'adresse ici : FindAgent n'admet un agent que si la sienne est déjà celle du
+      # jeton, à la normalisation près. La réécrire ne changerait rien.
+      class SyncAgentIdentity
+        include Interactor
+
+        def call
+          context.agent.update!(
+            provider_sub: context.claims[:sub],
+            first_name: context.info[:first_name],
+            last_name: context.info[:last_name]
+          )
+        rescue ActiveRecord::RecordNotUnique, ActiveRecord::RecordInvalid
+          # Deux connexions simultanées d'un agent jamais rattaché : la seconde bute sur
+          # l'index unique. L'agent est légitime et réessayer aboutira, l'autre requête
+          # ayant déjà posé le `sub` — d'où la page d'échec, qui invite à recommencer.
+          context.fail!(error: :sign_in_conflict)
+        end
+      end
+    end
+  end
+end

--- a/app/interactors/portail/sessions/create/verify_id_token.rb
+++ b/app/interactors/portail/sessions/create/verify_id_token.rb
@@ -15,6 +15,11 @@ module Portail
         rescue Portail::ProConnect::TokenVerifier::InvalidToken => e
           Rails.logger.warn("[ProConnect] id_token rejected: #{e.message}")
           context.fail!(error: :invalid_token)
+        rescue Portail::ProConnect::Discovery::Unavailable => e
+          # Vérifier la signature suppose d'aller chercher les clés publiques. ProConnect
+          # muet, on ne peut ni accepter ni imputer quoi que ce soit à l'agent.
+          Rails.logger.error("[ProConnect] discovery unavailable: #{e.message}")
+          context.fail!(error: :provider_unavailable)
         end
       end
     end

--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -15,5 +15,8 @@ class Agent < ApplicationRecord
   # Nul tant que l'agent n'a pas ouvert sa première session : c'est ProConnect qui
   # l'attribue à la connexion. Un agent enrôlé existe donc avant d'en avoir un.
   validates :provider_sub, uniqueness: true, allow_nil: true
-  validates :email, presence: true
+
+  # L'adresse résout l'agent à la connexion : partagée par deux agents, la résolution
+  # en désignerait un au hasard. Toujours normalisée, donc comparable telle quelle.
+  validates :email, presence: true, uniqueness: true
 end

--- a/app/models/organization_link.rb
+++ b/app/models/organization_link.rb
@@ -3,10 +3,17 @@
 # Référence vers une organisation du référentiel V1, identifiée par son SIRET.
 # Ne porte aucune copie de l'organisation : le nom d'affichage sera lu en direct.
 class OrganizationLink < ApplicationRecord
+  # === Constants ===
+  # Format INSEE, redéclaré plutôt qu'emprunté à Organization : ce modèle appartient à
+  # l'API V2 gelée, on ne s'y couple pas pour une ligne.
+  SIRET_FORMAT = /\A\d{14}\z/
+
   # === Associations ===
   has_many :memberships, dependent: :restrict_with_error
   has_many :agents, through: :memberships
 
   # === Validations ===
-  validates :siret, presence: true, uniqueness: true
+  # Le SIRET est la clé de jointure vers le référentiel V1 : mal formé, le lien ne
+  # correspondra jamais à rien et l'agent sera refusé sans qu'on sache pourquoi.
+  validates :siret, presence: true, uniqueness: true, format: {with: SIRET_FORMAT}
 end

--- a/app/views/portail/dashboard/index.html.erb
+++ b/app/views/portail/dashboard/index.html.erb
@@ -6,13 +6,15 @@
     <p class="fr-text--lead"><%= t(".lead") %></p>
 
     <% if agent_signed_in? %>
-      <p><%= t(".signed_in_as", name: current_agent.first_name) %></p>
+      <div class="fr-callout fr-mb-4w">
+        <p class="fr-callout__text"><%= t(".signed_in_as", name: current_agent.first_name) %></p>
+      </div>
+
       <%# Déconnexion : redirection cross-origin vers ProConnect (SLO), que Turbo ne
           sait pas rendre — il laisserait la page inchangée. Hors Turbo, donc. %>
       <%= button_to t(".sign_out"), logout_path, method: :delete, class: "fr-btn fr-btn--secondary",
             form: {data: {turbo: false}} %>
     <% else %>
-      <p><%= t(".body") %></p>
       <%= render "portail/sessions/proconnect_button" %>
     <% end %>
   </div>

--- a/app/views/portail/dashboard/index.html.erb
+++ b/app/views/portail/dashboard/index.html.erb
@@ -5,17 +5,7 @@
     <h1><%= t(".heading") %></h1>
     <p class="fr-text--lead"><%= t(".lead") %></p>
 
-    <% if agent_signed_in? %>
-      <div class="fr-callout fr-mb-4w">
-        <p class="fr-callout__text"><%= t(".signed_in_as", name: current_agent.first_name) %></p>
-      </div>
-
-      <%# Déconnexion : redirection cross-origin vers ProConnect (SLO), que Turbo ne
-          sait pas rendre — il laisserait la page inchangée. Hors Turbo, donc. %>
-      <%= button_to t(".sign_out"), logout_path, method: :delete, class: "fr-btn fr-btn--secondary",
-            form: {data: {turbo: false}} %>
-    <% else %>
-      <%= render "portail/sessions/proconnect_button" %>
-    <% end %>
+    <%# Connecté, l'identité et la déconnexion vivent dans les accès rapides de l'en-tête. %>
+    <%= render "portail/sessions/proconnect_button" unless agent_signed_in? %>
   </div>
 </div>

--- a/app/views/portail/sessions/_proconnect_button.html.erb
+++ b/app/views/portail/sessions/_proconnect_button.html.erb
@@ -1,11 +1,12 @@
 <%# locals: () %>
 <%# Bouton officiel ProConnect (markup imposé, cf. doc partenaires ProConnect). %>
 <%# Phase requête OmniAuth : POST protégé CSRF (omniauth-rails_csrf_protection). %>
-<div>
+<%# L'espacement est porté ici, pas dans la feuille de marque, qui ne doit pas bouger. %>
+<div class="fr-mt-4w">
   <%= button_to "/auth/proconnect", class: "proconnect-button", form: {data: {turbo: false}} do %>
     <span class="proconnect-sr-only"><%= t("portail.sessions.proconnect_button.label") %></span>
   <% end %>
-  <p>
+  <p class="fr-mt-1w fr-mb-0">
     <%= link_to t("portail.sessions.proconnect_button.info"),
           "https://www.proconnect.gouv.fr/",
           target: "_blank", rel: "noopener noreferrer",

--- a/app/views/portail/sessions/denied.html.erb
+++ b/app/views/portail/sessions/denied.html.erb
@@ -4,11 +4,33 @@
   <div class="fr-col-12 fr-col-md-8">
     <h1><%= t("portail.sessions.denied.#{@denial_reason}.heading") %></h1>
     <p class="fr-text--lead"><%= t("portail.sessions.denied.#{@denial_reason}.body") %></p>
-    <p><%= t("portail.sessions.denied.authenticated_with", email: @authenticated_email) %></p>
-    <p><%= t("portail.sessions.denied.support", email: "support@hubee.numerique.gouv.fr") %></p>
-    <p><%= t("portail.sessions.denied.switch_account_hint") %></p>
-    <%# Lien externe (end_session ProConnect) : Turbo n'intercepte pas le cross-origin. %>
-    <%= link_to t("portail.sessions.denied.switch_account"), @switch_account_url, class: "fr-btn" %>
-    <%= link_to t("portail.errors.back_home"), root_path, class: "fr-btn fr-btn--secondary" %>
+
+    <p>
+      <%# Clé _html : Rails échappe l'interpolation sauf si elle est déjà sûre, ce que
+          mail_to garantit. %>
+      <%= t("portail.sessions.denied.support_html", email: mail_to(support_email)) %>
+    </p>
+
+    <%# L'adresse qualifie le refus, et reste juste au-dessus de l'action. %>
+    <p class="fr-text--sm fr-mb-1w">
+      <%= t("portail.sessions.denied.authenticated_with", email: @authenticated_email) %>
+    </p>
+
+    <% if @switch_account_url %>
+      <%# Avant le bouton, pas après : il déconnecte de ProConnect pour tous les services. %>
+      <p class="fr-hint-text fr-mb-2w"><%= t("portail.sessions.denied.switch_account_hint") %></p>
+    <% end %>
+
+    <ul class="fr-btns-group fr-btns-group--inline-md">
+      <% if @switch_account_url %>
+        <li>
+          <%# Lien externe (end_session ProConnect) : Turbo n'intercepte pas le cross-origin. %>
+          <%= link_to t("portail.sessions.denied.switch_account"), @switch_account_url, class: "fr-btn" %>
+        </li>
+      <% end %>
+      <li>
+        <%= link_to t("portail.errors.back_home"), root_path, class: "fr-btn fr-btn--secondary" %>
+      </li>
+    </ul>
   </div>
 </div>

--- a/app/views/portail/shared/_header.html.erb
+++ b/app/views/portail/shared/_header.html.erb
@@ -18,6 +18,32 @@
             <p class="fr-header__service-tagline"><%= t("tagline") %></p>
           </div>
         </div>
+
+        <% if agent_signed_in? %>
+          <%# Accès rapides du DSFR. Le contenu de fr-header__tools-links est recopié
+              automatiquement dans fr-header__menu-links pour le mobile — l'identité doit
+              donc rester à l'intérieur, sans quoi elle disparaîtrait sur petit écran. %>
+          <div class="fr-header__tools">
+            <div class="fr-header__tools-links">
+              <ul class="fr-btns-group">
+                <li>
+                  <%# Même rembourrage vertical que le bouton : les <li> du groupe étant
+                      alignés en haut, c'est ce qui met les deux textes sur la même ligne. %>
+                  <p class="fr-text--sm fr-m-0 fr-py-1v">
+                    <%= t(".signed_in_as", name: current_agent.first_name, email: current_agent.email) %>
+                  </p>
+                </li>
+                <li>
+                  <%# Déconnexion : redirection cross-origin vers ProConnect (SLO), que Turbo
+                      ne sait pas rendre — il laisserait la page inchangée. Hors Turbo, donc. %>
+                  <%= button_to t(".sign_out"), logout_path, method: :delete,
+                        class: "fr-btn fr-btn--icon-left fr-icon-logout-box-r-line",
+                        form: {data: {turbo: false}} %>
+                </li>
+              </ul>
+            </div>
+          </div>
+        <% end %>
       </div>
     </div>
   </div>

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -2,6 +2,14 @@ fr:
   app_name: HubEE
   tagline: Plateforme d'échange sécurisé de fichiers entre administrations
 
+  activerecord:
+    errors:
+      models:
+        organization_link:
+          attributes:
+            siret:
+              invalid: doit comporter 14 chiffres
+
   portail:
     shared:
       skip_links:
@@ -30,8 +38,7 @@ fr:
       index:
         title: Portail HubEE
         heading: Portail HubEE
-        lead: Espace de gestion réservé aux administrations (accessible après authentification).
-        body: Le portail V2 est en cours de construction. Cette page sera remplacée par le tableau de bord une fois l'authentification en place.
+        lead: Espace de gestion réservé aux administrations.
         sign_out: Se déconnecter
         signed_in_as: "Connecté en tant que %{name}"
     sessions:
@@ -41,30 +48,33 @@ fr:
         info_title: Qu'est-ce que ProConnect ? - nouvelle fenêtre
       create:
         signed_in: Vous êtes connecté.
+      destroy:
+        provider_unavailable: Vous êtes déconnecté du portail. ProConnect étant momentanément indisponible, votre session ProConnect reste ouverte.
       denied:
         title: Accès refusé — HubEE
-        authenticated_with: "Vous vous êtes authentifié avec l'adresse %{email}."
-        support: "Si vous pensez qu'il s'agit d'une erreur, écrivez à %{email} en précisant cette adresse et l'heure de votre tentative."
-        switch_account_hint: Vous pouvez réessayer avec un autre compte. Vous serez d'abord déconnecté de ProConnect.
+        authenticated_with: "Adresse utilisée : %{email}"
+        support_html: "Si vous pensez qu'il s'agit d'une erreur ou si vous avez besoin d'aide, écrivez à %{email} en précisant l'heure de votre tentative."
+        switch_account_hint: Réessayer avec un autre compte vous déconnectera d'abord de ProConnect.
         switch_account: Essayer avec un autre compte
         unknown_agent:
-          heading: Vous êtes authentifié, mais votre compte n'est pas reconnu
-          body: Votre identité a bien été vérifiée par ProConnect, mais aucun compte HubEE ne lui est associé. Aucun compte n'a été créé. Rapprochez-vous de votre administration pour être enrôlé.
+          heading: Votre compte n'est pas reconnu
+          body: Votre identité est vérifiée, mais aucun compte HubEE ne lui correspond. Demandez à votre administration de vous déclarer.
         insufficient_authentication_level:
-          heading: Votre méthode de connexion ne permet pas d'accéder au portail
-          body: HubEE exige que votre organisation soit attestée par votre fournisseur d'identité. La connexion que vous venez d'utiliser ne l'atteste pas.
+          heading: Votre rattachement n'a pas été vérifié
+          body: "L'organisation de votre compte est déclarative : HubEE exige qu'elle soit vérifiée. Reconnectez-vous avec le compte fourni par votre administration."
         organization_mismatch:
-          heading: Vous n'êtes rattaché à aucune organisation sur ce portail
-          body: Votre identité a bien été vérifiée, mais aucun rattachement ne vous autorise à entrer dans HubEE au titre de l'organisation avec laquelle vous vous êtes connecté. Rapprochez-vous de votre administration.
+          heading: Vous n'êtes pas autorisé au titre de cette organisation
+          body: "Aucun rattachement ne vous autorise à entrer au titre de l'organisation choisie. Si vous en avez plusieurs, réessayez avec une autre ; sinon, contactez votre administration."
         email_mismatch:
-          heading: Votre adresse de connexion ne correspond pas à votre compte
-          body: Le compte ProConnect que vous venez d'utiliser est bien connu du portail, mais l'adresse électronique qui lui est associée a changé. Par précaution, l'accès est suspendu le temps que votre administration mette votre compte à jour.
+          heading: Votre adresse ne correspond pas à votre compte
+          body: "L'adresse de votre compte ProConnect n'est plus celle enregistrée par HubEE. Par précaution, l'accès est suspendu : demandez sa mise à jour à votre administration."
       failure:
         title: Échec de la connexion — HubEE
         heading: La connexion a échoué
         body: Une erreur est survenue pendant l'authentification. Aucune session n'a été ouverte. Vous pouvez réessayer.
     errors:
       back_home: Retour à l'accueil
+      stale_page: Cette page n'était plus à jour, elle a été rechargée.
       not_found:
         title: Page introuvable — HubEE
         heading: Page introuvable

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -23,6 +23,8 @@ fr:
         close: Fermer
         nav_label: Menu principal
         home: Accueil
+        signed_in_as: "Connecté en tant que %{name} (%{email})"
+        sign_out: Se déconnecter
       footer:
         home_title: Retour à l'accueil du site — HubEE — République Française
         description: HubEE — Plateforme d'échange sécurisé de fichiers entre administrations.
@@ -39,8 +41,6 @@ fr:
         title: Portail HubEE
         heading: Portail HubEE
         lead: Espace de gestion réservé aux administrations.
-        sign_out: Se déconnecter
-        signed_in_as: "Connecté en tant que %{name}"
     sessions:
       proconnect_button:
         label: S'identifier avec ProConnect

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -44,5 +44,8 @@ Rails.application.routes.draw do
   # La phase requête POST /auth/proconnect est interceptée par le middleware OmniAuth.
   get "auth/proconnect/callback", to: "portail/sessions#create"
   get "auth/failure", to: "portail/sessions#failure", as: :auth_failure
+  # Le callback porte un code à usage unique : il redirige ici plutôt que de rendre le
+  # refus, sinon la page ne serait ni rechargeable ni partageable.
+  get "connexion/refusee", to: "portail/sessions#denied", as: :denied
   delete "logout", to: "portail/sessions#destroy", as: :logout
 end

--- a/db/migrate/20260720100000_create_agents.rb
+++ b/db/migrate/20260720100000_create_agents.rb
@@ -5,10 +5,10 @@ class CreateAgents < ActiveRecord::Migration[8.1]
       t.string :email, null: false
       t.string :first_name
       t.string :last_name
-      t.string :amr, array: true, null: false, default: []
       t.timestamps
     end
 
     add_index :agents, :provider_sub, unique: true
+    add_index :agents, :email, unique: true
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -19,13 +19,13 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_03_120100) do
   create_enum "data_package_state", ["draft", "transmitted", "acknowledged"]
 
   create_table "agents", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
-    t.string "amr", default: [], null: false, array: true
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.string "first_name"
     t.string "last_name"
     t.string "provider_sub"
     t.datetime "updated_at", null: false
+    t.index ["email"], name: "index_agents_on_email", unique: true
     t.index ["provider_sub"], name: "index_agents_on_provider_sub", unique: true
   end
 

--- a/lib/omni_auth/strategies/proconnect_hardened.rb
+++ b/lib/omni_auth/strategies/proconnect_hardened.rb
@@ -5,11 +5,16 @@ require "omniauth/proconnect"
 module OmniAuth
   module Strategies
     # Durcit la stratégie ProConnect de la gem 0.6 :
-    #  - demande explicitement le claim `amr` (paramètre `claims`) — la gem ne le fait pas ;
+    #  - demande explicitement `amr` (paramètre `claims`) et `acr` (`acr_values`) — la gem
+    #    ne demande ni l'un ni l'autre, et ProConnect ne les émet pas spontanément ;
     #  - expose l'id_token brut (credentials) et le nonce émis (extra) dans le auth hash,
     #    pour que Portail::Sessions::Create vérifie signature + nonce côté app.
     class ProconnectHardened < Proconnect
       option :name, "proconnect"
+
+      # Le plancher demandé à ProConnect, aligné sur le premier niveau que le portail
+      # accepte. Voir Portail::Sessions::Create::CheckAuthenticationLevel.
+      MINIMUM_AUTHENTICATION_LEVEL = "eidas1"
 
       credentials do
         {id_token: session["omniauth.pc.id_token"]}
@@ -30,7 +35,12 @@ module OmniAuth
             scope: options[:scope],
             state: store_new_state!,
             nonce: store_new_nonce!,
-            claims: {id_token: {amr: {essential: true}}}.to_json
+            claims: {id_token: {amr: {essential: true}}}.to_json,
+            # Sans `acr_values`, ProConnect n'émet aucun `acr` — le demander via `claims`
+            # ne suffit pas — et CheckAuthenticationLevel refuserait alors tout le monde.
+            # La valeur annonce notre minimum ; elle ne dispense pas de vérifier le niveau
+            # réellement atteint au retour, seul contrôle qui fasse foi.
+            acr_values: MINIMUM_AUTHENTICATION_LEVEL
           )
         end
       end

--- a/lib/portail/pro_connect/discovery.rb
+++ b/lib/portail/pro_connect/discovery.rb
@@ -15,6 +15,16 @@ module Portail
     # TokenVerifier et LogoutUrlBuilder s'exécutent ailleurs — dans un interactor et dans
     # un controller — et n'y ont donc pas accès.
     class Discovery
+      # ProConnect n'a pas répondu, ou pas de façon exploitable. Distinct d'un bug de
+      # notre côté : les appelants doivent pouvoir dégrader plutôt que tomber.
+      class Unavailable < StandardError; end
+
+      # Tout ce qui peut sortir de Net::HTTP quand le réseau ou le pair fait défaut.
+      NETWORK_ERRORS = [
+        Errno::ECONNREFUSED, Errno::ECONNRESET, Errno::EHOSTUNREACH,
+        Net::OpenTimeout, Net::ReadTimeout, SocketError, OpenSSL::SSL::SSLError, IOError
+      ].freeze
+
       DISCOVERY_PATH = "/.well-known/openid-configuration"
       # Le cache évite un appel HTTP à chaque vérification de jeton. Il n'est pas ce qui
       # nous fait récupérer les nouvelles clés : #jwks s'en charge, immédiatement.
@@ -27,11 +37,11 @@ module Portail
       READ_TIMEOUT = 5
 
       def issuer
-        config.fetch("issuer")
+        config_value("issuer")
       end
 
       def end_session_endpoint
-        config.fetch("end_session_endpoint")
+        config_value("end_session_endpoint")
       end
 
       # Tout jeton signé porte dans son en-tête, en clair, l'identifiant de la clé qui a
@@ -60,7 +70,7 @@ module Portail
       def cached_jwks(force: false)
         Rails.cache.delete(JWKS_CACHE_KEY) if force
         raw = Rails.cache.fetch(JWKS_CACHE_KEY, expires_in: CACHE_TTL) do
-          fetch_json(config.fetch("jwks_uri"))
+          fetch_json(config_value("jwks_uri"))
         end
         JSON::JWK::Set.new(raw)
       end
@@ -78,6 +88,14 @@ module Portail
         end
       end
 
+      # Un annuaire amputé de la clé attendue est aussi inexploitable qu'une absence de
+      # réponse : même traitement, pour que les appelants n'aient qu'un cas à gérer.
+      def config_value(key)
+        config.fetch(key)
+      rescue KeyError
+        raise Unavailable, "annuaire ProConnect sans #{key}"
+      end
+
       def fetch_json(url)
         uri = URI(url)
         # On exige HTTPS au lieu de le déduire de l'URL. Récupérées en clair, les clés
@@ -91,7 +109,14 @@ module Portail
           open_timeout: OPEN_TIMEOUT,
           read_timeout: READ_TIMEOUT
         ) { |http| http.get(uri.request_uri) }
+
+        # Sans ce contrôle, une page d'erreur HTML renvoyée par un intermédiaire
+        # ressortirait en JSON::ParserError, indiscernable d'un bug de parsing.
+        raise Unavailable, "#{url} a répondu #{response.code}" unless response.is_a?(Net::HTTPSuccess)
+
         JSON.parse(response.body)
+      rescue *NETWORK_ERRORS, JSON::ParserError => e
+        raise Unavailable, "#{url} injoignable ou illisible (#{e.class})"
       end
     end
   end

--- a/lib/portail/pro_connect/token_verifier.rb
+++ b/lib/portail/pro_connect/token_verifier.rb
@@ -21,6 +21,11 @@ module Portail
       # Le premier cas est couvert par token_verifier_spec.rb.
       ALLOWED_ALGORITHMS = [:RS256].freeze
 
+      # Deux horloges ne sont jamais parfaitement d'accord. Sans marge, quelques secondes
+      # de dérive suffiraient à refuser des jetons valides — panne intermittente et
+      # difficile à imputer. Trente secondes est l'usage courant.
+      CLOCK_LEEWAY = 30.seconds
+
       class << self
         def call(id_token:, nonce:, audience:, discovery: Discovery.new)
           new(id_token:, nonce:, audience:, discovery:).call
@@ -75,7 +80,7 @@ module Portail
         raise InvalidToken, "missing subject" if claims[:sub].blank?
         raise InvalidToken, "issuer mismatch" unless claims[:iss] == discovery.issuer
         raise InvalidToken, "audience mismatch" unless Array(claims[:aud]).include?(audience)
-        raise InvalidToken, "token expired" if claims[:exp].to_i <= Time.current.to_i
+        raise InvalidToken, "token expired" if claims[:exp].to_i <= (Time.current - CLOCK_LEEWAY).to_i
         raise InvalidToken, "nonce mismatch" unless nonce.present? && claims[:nonce] == nonce
       end
     end

--- a/spec/factories/agents.rb
+++ b/spec/factories/agents.rb
@@ -4,6 +4,5 @@ FactoryBot.define do
     sequence(:email) { |n| "agent#{n}@example.gouv.fr" }
     first_name { "Camille" }
     last_name { "Martin" }
-    amr { ["pwd"] }
   end
 end

--- a/spec/interactors/portail/sessions/create/find_agent_spec.rb
+++ b/spec/interactors/portail/sessions/create/find_agent_spec.rb
@@ -11,29 +11,26 @@ RSpec.describe Portail::Sessions::Create::FindAgent do
   end
 
   context "when an agent matches both the sub and the email" do
-    it "returns the agent and refreshes names and authentication methods" do
+    it "returns the agent without writing" do
       agent = create(:agent, provider_sub: "sub-xyz", email: "new@example.gouv.fr",
-        first_name: "Alexandre", last_name: "Ancien", amr: ["pwd"])
+        first_name: "Alexandre", last_name: "Ancien")
 
       expect(result).to be_success
       expect(result.agent).to eq(agent)
-      expect(agent.reload).to have_attributes(
-        first_name: "Alex",
-        last_name: "Nouveau",
-        amr: ["pwd", "mfa"]
-      )
+      # Aligner la fiche revient à SyncAgentIdentity, une fois l'accès accordé.
+      expect(agent.reload).to have_attributes(first_name: "Alexandre", last_name: "Ancien")
     end
   end
 
   # Premier rapprochement d'un agent enrôlé, ou retour après un changement de fournisseur
   # d'identité — qui change le sub sans changer la personne.
   context "when no agent matches the sub but one holds the email" do
-    it "binds the sub to that agent and lets them in" do
+    it "resolves that agent without binding the sub yet" do
       agent = create(:agent, provider_sub: "sub-other", email: "new@example.gouv.fr")
 
       expect(result).to be_success
       expect(result.agent).to eq(agent)
-      expect(agent.reload.provider_sub).to eq("sub-xyz")
+      expect(agent.reload.provider_sub).to eq("sub-other")
     end
   end
 
@@ -51,12 +48,11 @@ RSpec.describe Portail::Sessions::Create::FindAgent do
 
   # Le cas nominal de l'enrôlement : l'agent existe, il n'a jamais ouvert de session.
   context "when the enrolled agent has no sub yet" do
-    it "binds the sub on this first login" do
+    it "resolves the agent by email" do
       agent = create(:agent, provider_sub: nil, email: "new@example.gouv.fr")
 
       expect(result).to be_success
       expect(result.agent).to eq(agent)
-      expect(agent.reload.provider_sub).to eq("sub-xyz")
     end
   end
 

--- a/spec/interactors/portail/sessions/create/sync_agent_identity_spec.rb
+++ b/spec/interactors/portail/sessions/create/sync_agent_identity_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Portail::Sessions::Create::SyncAgentIdentity do
+  describe ".call" do
+    it "binds the ProConnect account and refreshes the identity it attests" do
+      agent = create(:agent, provider_sub: nil, first_name: "Alexandre", last_name: "Ancien")
+
+      result = described_class.call(
+        agent: agent,
+        claims: {sub: "sub-xyz"},
+        info: {first_name: "Alex", last_name: "Nouveau"}
+      )
+
+      expect(result).to be_success
+      expect(agent.reload).to have_attributes(
+        provider_sub: "sub-xyz",
+        first_name: "Alex",
+        last_name: "Nouveau"
+      )
+    end
+
+    # Deux connexions simultanées d'un agent jamais rattaché : la seconde bute sur
+    # l'index unique. Sans ce rescue, l'exception traverserait jusqu'au 500.
+    it "fails with sign_in_conflict when the sub was bound concurrently" do
+      agent = create(:agent, provider_sub: nil)
+      create(:agent, provider_sub: "sub-xyz")
+
+      result = described_class.call(agent: agent, claims: {sub: "sub-xyz"}, info: {})
+
+      expect(result).to be_failure
+      expect(result.error).to eq(:sign_in_conflict)
+    end
+  end
+end

--- a/spec/interactors/portail/sessions/create/verify_id_token_spec.rb
+++ b/spec/interactors/portail/sessions/create/verify_id_token_spec.rb
@@ -33,4 +33,16 @@ RSpec.describe Portail::Sessions::Create::VerifyIdToken do
       expect(result.error).to eq(:invalid_token)
     end
   end
+
+  # Vérifier la signature suppose d'aller chercher les clés publiques : ProConnect muet,
+  # on ne peut rien imputer à l'agent — c'est une panne, pas un refus.
+  context "when ProConnect cannot be reached" do
+    it "fails with provider_unavailable" do
+      expect(Portail::ProConnect::TokenVerifier).to receive(:call)
+        .and_raise(Portail::ProConnect::Discovery::Unavailable)
+
+      expect(result).to be_failure
+      expect(result.error).to eq(:provider_unavailable)
+    end
+  end
 end

--- a/spec/interactors/portail/sessions/create_spec.rb
+++ b/spec/interactors/portail/sessions/create_spec.rb
@@ -22,7 +22,8 @@ RSpec.describe Portail::Sessions::Create do
 
   context "when the token is valid and the agent is attached to the certified organisation" do
     it "runs the whole chain and resolves both the agent and the membership" do
-      agent = create(:agent, provider_sub: "sub-xyz", email: "agent@example.gouv.fr")
+      agent = create(:agent, provider_sub: nil, email: "agent@example.gouv.fr",
+        first_name: "Ancien")
       link = create(:organization_link, siret: "99999999911111")
       membership = create(:membership, agent: agent, organization_link: link)
       expect(Portail::ProConnect::TokenVerifier).to receive(:call)
@@ -31,6 +32,23 @@ RSpec.describe Portail::Sessions::Create do
       expect(result).to be_success
       expect(result.agent).to eq(agent)
       expect(result.membership).to eq(membership)
+      expect(agent.reload).to have_attributes(provider_sub: "sub-xyz", first_name: "Alex")
+    end
+  end
+
+  # Le refus tombe après la résolution de l'agent : la chaîne ne doit rien avoir écrit.
+  context "when the agent is attached to another organisation" do
+    it "fails without touching the agent record" do
+      agent = create(:agent, provider_sub: nil, email: "agent@example.gouv.fr",
+        first_name: "Inchangé")
+      create(:membership, agent: agent,
+        organization_link: create(:organization_link, siret: "11111111122222"))
+      expect(Portail::ProConnect::TokenVerifier).to receive(:call)
+        .and_return(sub: "sub-xyz", amr: ["mfa"], acr: "eidas1")
+
+      expect(result).to be_failure
+      expect(result.error).to eq(:organization_mismatch)
+      expect(agent.reload).to have_attributes(provider_sub: nil, first_name: "Inchangé")
     end
   end
 end

--- a/spec/lib/omni_auth/strategies/proconnect_hardened_spec.rb
+++ b/spec/lib/omni_auth/strategies/proconnect_hardened_spec.rb
@@ -14,7 +14,9 @@ RSpec.describe OmniAuth::Strategies::ProconnectHardened do
   end
 
   describe "#authorization_uri" do
-    it "requests the amr claim as essential in the id_token" do
+    # Sans acr_values, ProConnect n'émet aucun acr et toute connexion serait refusée
+    # faute de niveau d'authentification constatable.
+    it "requests the amr claim as essential and the minimum authentication level" do
       expect(strategy).to receive(:discovered_configuration)
         .and_return("authorization_endpoint" => "https://proconnect.gouv.fr/api/v2/authorize")
       expect(strategy).to receive(:store_new_state!).and_return("state-1")
@@ -24,6 +26,7 @@ RSpec.describe OmniAuth::Strategies::ProconnectHardened do
       params = Rack::Utils.parse_query(URI(uri).query)
 
       expect(params["claims"]).to eq({id_token: {amr: {essential: true}}}.to_json)
+      expect(params["acr_values"]).to eq("eidas1")
       expect(params["scope"]).to eq("openid given_name usual_name email")
     end
   end

--- a/spec/lib/portail/pro_connect/discovery_spec.rb
+++ b/spec/lib/portail/pro_connect/discovery_spec.rb
@@ -41,6 +41,40 @@ RSpec.describe Portail::ProConnect::Discovery do
     end
   end
 
+  # Une panne de ProConnect doit se présenter aux appelants sous une seule forme, pour
+  # qu'ils puissent dégrader au lieu de laisser fuir une exception de transport.
+  describe "when ProConnect cannot be reached or understood" do
+    it "raises Unavailable on a non-success response" do
+      stub_request(:get, "#{domain}/.well-known/openid-configuration")
+        .to_return(status: 502, body: "<html>Bad Gateway</html>")
+
+      expect { described_class.new.issuer }
+        .to raise_error(described_class::Unavailable, /502/)
+    end
+
+    it "raises Unavailable when the connection fails" do
+      stub_request(:get, "#{domain}/.well-known/openid-configuration").to_timeout
+
+      expect { described_class.new.issuer }.to raise_error(described_class::Unavailable)
+    end
+
+    it "raises Unavailable when the body is not the expected JSON" do
+      stub_request(:get, "#{domain}/.well-known/openid-configuration")
+        .to_return(status: 200, body: "pas du json")
+
+      expect { described_class.new.issuer }.to raise_error(described_class::Unavailable)
+    end
+
+    # Un annuaire bien formé mais amputé est tout aussi inexploitable.
+    it "raises Unavailable when the expected key is missing" do
+      stub_request(:get, "#{domain}/.well-known/openid-configuration")
+        .to_return(status: 200, body: {jwks_uri: "https://x.test/jwks"}.to_json)
+
+      expect { described_class.new.issuer }
+        .to raise_error(described_class::Unavailable, /issuer/)
+    end
+  end
+
   describe "#end_session_endpoint" do
     it "returns the end_session_endpoint from the discovery document" do
       expect(described_class.new.end_session_endpoint).to eq("https://proconnect.gouv.fr/api/v2/session/end")

--- a/spec/lib/portail/pro_connect/token_verifier_spec.rb
+++ b/spec/lib/portail/pro_connect/token_verifier_spec.rb
@@ -105,6 +105,15 @@ RSpec.describe Portail::ProConnect::TokenVerifier do
       end
     end
 
+    # Sans marge, une horloge en avance de quelques secondes refuserait des jetons valides.
+    context "when the token expired within the clock leeway" do
+      let(:id_token) { signed_id_token(exp: 10.seconds.ago.to_i) }
+
+      it "still accepts it" do
+        expect(result[:sub]).to eq("sub-xyz")
+      end
+    end
+
     context "when the token is signed with a non-allowed algorithm" do
       let(:id_token) do
         claims = {

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -11,6 +11,10 @@ RSpec.describe Agent, type: :model do
     # Un agent enrôlé existe avant d'avoir ouvert sa première session.
     it { is_expected.to allow_value(nil).for(:provider_sub) }
     it { is_expected.to validate_presence_of(:email) }
+
+    # ignoring_case_sensitivity : le matcher éprouve la casse en la permutant, or
+    # `normalizes` la rabat en minuscules — la permutation entre donc en collision.
+    it { is_expected.to validate_uniqueness_of(:email).ignoring_case_sensitivity }
   end
 
   describe "associations" do

--- a/spec/models/organization_link_spec.rb
+++ b/spec/models/organization_link_spec.rb
@@ -11,6 +11,12 @@ RSpec.describe OrganizationLink, type: :model do
     # ignoring_case_sensitivity : le matcher éprouve la casse en la permutant, or un SIRET
     # n'a que des chiffres — il n'a rien à permuter et refuse de conclure.
     it { is_expected.to validate_uniqueness_of(:siret).ignoring_case_sensitivity }
+
+    it { is_expected.to allow_value("13002526500013").for(:siret) }
+
+    # Un SIRET espacé ou tronqué ne correspondrait jamais à celui attesté par ProConnect.
+    it { is_expected.not_to allow_value("130 025 265 00013").for(:siret) }
+    it { is_expected.not_to allow_value("1300252650001").for(:siret) }
   end
 
   describe "associations" do

--- a/spec/requests/portail/sessions_spec.rb
+++ b/spec/requests/portail/sessions_spec.rb
@@ -36,8 +36,10 @@ RSpec.describe "Portail::Sessions", type: :request do
           get "/auth/proconnect/callback"
         }.not_to change(Agent, :count)
 
+        expect(response).to redirect_to(denied_path)
+        follow_redirect!
         expect(response).to have_http_status(:forbidden)
-        expect(Capybara.string(response.body)).to have_text("votre compte n'est pas reconnu")
+        expect(Capybara.string(response.body)).to have_text("Votre compte n'est pas reconnu")
         expect(Capybara.string(response.body)).to have_text("support@hubee.numerique.gouv.fr")
       end
 
@@ -47,6 +49,7 @@ RSpec.describe "Portail::Sessions", type: :request do
         mock_proconnect(sub: "sub-unknown", email: "alex@example.gouv.fr")
 
         get "/auth/proconnect/callback"
+        follow_redirect!
 
         page = Capybara.string(response.body)
         expect(page).to have_text("alex@example.gouv.fr")
@@ -63,9 +66,10 @@ RSpec.describe "Portail::Sessions", type: :request do
         mock_proconnect(sub: "sub-unknown", acr: "eidas0")
 
         get "/auth/proconnect/callback"
+        follow_redirect!
 
         expect(response).to have_http_status(:forbidden)
-        expect(Capybara.string(response.body)).to have_text("ne permet pas d'accéder au portail")
+        expect(Capybara.string(response.body)).to have_text("Votre rattachement n'a pas été vérifié")
       end
     end
 
@@ -78,9 +82,10 @@ RSpec.describe "Portail::Sessions", type: :request do
         mock_proconnect(sub: "sub-known", email: agent.email)
 
         get "/auth/proconnect/callback"
+        follow_redirect!
 
         expect(response).to have_http_status(:forbidden)
-        expect(Capybara.string(response.body)).to have_text("aucune organisation")
+        expect(Capybara.string(response.body)).to have_text("au titre de cette organisation")
       end
     end
 
@@ -92,6 +97,7 @@ RSpec.describe "Portail::Sessions", type: :request do
         mock_proconnect(sub: "sub-known", email: "other@example.gouv.fr")
 
         get "/auth/proconnect/callback"
+        follow_redirect!
 
         expect(response).to have_http_status(:forbidden)
         expect(Capybara.string(response.body)).to have_text("ne correspond pas à votre compte")
@@ -111,6 +117,58 @@ RSpec.describe "Portail::Sessions", type: :request do
 
         expect(response).to redirect_to(auth_failure_path)
       end
+    end
+  end
+
+  # Le callback porte un code à usage unique : rendre le refus sur son URL la rendait
+  # irrechargeable. Le motif vit en session, la page a sa propre adresse.
+  describe "GET /connexion/refusee" do
+    it "still explains the refusal when the page is reloaded" do
+      expect(Portail::ProConnect::LogoutUrlBuilder).to receive(:call).twice
+        .and_return("https://proconnect.test/session/end?id_token_hint=test-id-token")
+      mock_proconnect(sub: "sub-unknown")
+      get "/auth/proconnect/callback"
+
+      get denied_path
+      get denied_path
+
+      expect(response).to have_http_status(:forbidden)
+      expect(Capybara.string(response.body)).to have_text("Votre compte n'est pas reconnu")
+    end
+
+    it "sends the visitor home when no refusal is pending" do
+      get denied_path
+
+      expect(response).to redirect_to(root_path)
+    end
+  end
+
+  # Deux onglets, une seule session : celui qui agit en second présente le jeton d'avant
+  # le renouvellement. La requête doit être refusée sans exposer d'erreur brute.
+  describe "a page whose CSRF token has expired" do
+    it "reloads the home page instead of failing" do
+      agent = create(:agent, provider_sub: "sub-known")
+      sign_in_via_proconnect(agent:)
+      ActionController::Base.allow_forgery_protection = true
+
+      delete "/logout", params: {authenticity_token: "périmé"}
+
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(Capybara.string(response.body)).to have_text("Cette page n'était plus à jour")
+    ensure
+      ActionController::Base.allow_forgery_protection = false
+    end
+  end
+
+  # Une page ressortie du cache porterait un jeton CSRF périmé, et le bouton ProConnect
+  # échouerait en InvalidAuthenticityToken au clic suivant.
+  describe "browser caching" do
+    it "forbids storing portal pages" do
+      get root_path
+
+      expect(response).to have_http_status(:success)
+      expect(response.headers["Cache-Control"]).to eq("no-store")
     end
   end
 
@@ -185,6 +243,38 @@ RSpec.describe "Portail::Sessions", type: :request do
       delete "/logout"
 
       expect(response).to redirect_to("https://proconnect.test/session/end?id_token_hint=test-id-token")
+    end
+
+    # La session locale est détruite avant tout appel sortant : une panne de ProConnect ne
+    # doit jamais retenir un agent connecté au portail.
+    it "still signs the agent out of the portal when ProConnect is unreachable" do
+      agent = create(:agent, provider_sub: "sub-known")
+      sign_in_via_proconnect(agent:)
+      expect(Portail::ProConnect::LogoutUrlBuilder).to receive(:call)
+        .and_raise(Portail::ProConnect::Discovery::Unavailable)
+
+      delete "/logout"
+
+      expect(response).to redirect_to(root_path)
+      follow_redirect!
+      expect(Capybara.string(response.body)).to have_button("S'identifier avec ProConnect")
+    end
+  end
+
+  # Une panne du fournisseur n'est pas une décision sur l'agent : elle ne doit pas
+  # atterrir sur la page de refus, qui parlerait à tort de son compte.
+  describe "when ProConnect is unreachable during the callback" do
+    it "redirects to the failure page without opening a session" do
+      OmniAuth.config.mock_auth[:proconnect] = OmniAuth::AuthHash.new(
+        provider: "proconnect", uid: "x",
+        info: {email: "a@b.fr"}, credentials: {id_token: "t"}, extra: {nonce: "n"}
+      )
+      expect(Portail::ProConnect::TokenVerifier).to receive(:call)
+        .and_raise(Portail::ProConnect::Discovery::Unavailable)
+
+      get "/auth/proconnect/callback"
+
+      expect(response).to redirect_to(auth_failure_path)
     end
   end
 end


### PR DESCRIPTION
## Pourquoi

Le socle d'authentification ProConnect refusait **toutes** les connexions, sans exception : faute d'envoyer `acr_values` dans la requête d'autorisation, ProConnect n'émettait aucun `acr`, et le contrôle du niveau d'authentification concluait systématiquement à un niveau insuffisant. Le défaut était invisible en test, les specs court-circuitant la vérification du jeton.

Le diagnostic a mis au jour plusieurs autres fragilités, corrigées ici.

## Ce que ça change

**Débloquer les connexions.** `acr_values` est désormais transmis, aligné sur le premier niveau accepté par le portail. Le paramètre `claims` ne suffisait pas : ProConnect n'honore pas la demande d'`acr` par ce canal. Le contrôle applicatif du niveau reçu est conservé — on vérifie ce qu'on a obtenu, on ne fait pas confiance à ce qu'on a demandé.

**N'écrire qu'une fois l'accès accordé.** `FindAgent` mettait à jour l'agent avant que la décision soit rendue : une tentative refusée pour mauvaise organisation laissait sa trace en base et consommait le rattachement par adresse. La persistance passe dans une étape finale, après le contrôle du rattachement. Une course entre deux connexions simultanées se solde par un échec explicite, plus par un 500.

**Survivre à une panne de ProConnect.** Une indisponibilité du fournisseur remontait en 500, y compris sur la déconnexion — un tiers injoignable retenait un agent connecté. `Discovery` ramène désormais les défaillances réseau, les statuts non-2xx, les corps illisibles et les annuaires amputés à une erreur unique ; les appelants dégradent au lieu de tomber. La déconnexion locale est acquise avant tout appel sortant.

**Rendre le refus rechargeable.** La page de refus était rendue sur l'URL du callback, qui porte un code à usage unique : la recharger produisait une erreur, et l'adresse n'était ni partageable ni utilisable avec le bouton « précédent ». Elle a maintenant sa propre route, le motif transitant par la session.

**Fiabiliser l'identification.** L'`amr` quitte le modèle : il qualifie une authentification, pas une personne, et deux sessions concurrentes se contaminaient. Il rejoindra les événements d'authentification. L'adresse de l'agent devient unique, puisqu'elle sert de clé de résolution tant qu'aucun identifiant ProConnect n'est rattaché.

**Divers durcissements.** Trente secondes de tolérance d'horloge sur l'expiration des jetons ; un jeton CSRF périmé renvoie à l'accueil plutôt qu'à une erreur brute ; les pages du portail ne sont plus mises en cache par le navigateur ; validation du format du SIRET.

Les messages des pages de refus ont été resserrés et se terminent tous par une action que l'agent peut mener.

## Points d'attention pour la relecture

- **La migration de création des agents est réécrite en place** plutôt que complétée par une migration de retrait. L'application n'étant pas déployée et la base n'étant utilisée par personne d'autre, cela évite un aller-retour dans l'historique. À vérifier si un environnement a déjà joué cette migration : il conserverait la colonne `amr` et n'aurait pas l'index d'unicité.
- **Les six commits sont ordonnés pour rester bissectables** — chacun passe `bin/ci` seul. Les deux correctifs bloquants viennent en tête pour qu'un `revert` reste possible sans emporter le reste.

## Une contrainte mesurée : le cookie de session

Le cookie de session occupe **2768 octets connecté et 2604 après un refus, sur un plafond de 4096**. L'essentiel est l'`id_token` de ProConnect, conservé pour alimenter l'`id_token_hint` de la déconnexion — sans lui, ProConnect n'a plus de quoi valider notre `post_logout_redirect_uri`.

Ce n'est pas un défaut de conception : porter l'`id_token` en session est la manière habituelle d'implémenter la déconnexion initiée par le service, et la gem le faisait déjà avant nous — elle y écrivait les trois jetons, là où nous n'en gardons qu'un après `reset_session`. Ce qui est inhabituel, c'est le rapport entre la taille du jeton émis par ProConnect et le budget de 4 ko.

Rien à faire aujourd'hui : les valeurs sont stables — l'`id_token` ne contient ni adresse, ni nom, ni SIRET, donc sa taille ne varie pas d'un agent à l'autre — et il reste environ 1300 octets de marge, largement de quoi absorber un message flash. Mais le plafond est invisible dans le code, d'où ces chiffres consignés ici comme point de comparaison.

**À traiter avant, et non après, le premier de ces trois événements :** un claim supplémentaire demandé dans l'`id_token` ; le premier écran métier qui retient un état en session ; toute mesure au-delà de 3400 octets.

## Reste ouvert

`organization_mismatch` est le seul refus que l'agent ne peut pas diagnostiquer seul : on lui parle de « l'organisation choisie » sans la nommer. La nommer suppose d'ajouter `organization_label` au `scope` demandé à ProConnect.
