### PR TITLE
feat(agents): accueillir le profil et les habilitations des agents

### DIFF
--- a/app/models/agent.rb
+++ b/app/models/agent.rb
@@ -5,6 +5,11 @@ class Agent < ApplicationRecord
   has_many :memberships, dependent: :destroy
   has_many :organization_links, through: :memberships
 
+  # === Enums ===
+  # Liste fermée sans type PostgreSQL derrière (contrairement au rôle du rattachement) :
+  # une civilité fausse est un défaut d'affichage, pas un privilège usurpé
+  enum :civility, {mr: "mr", ms: "ms"}, prefix: true, validate: {allow_nil: true}
+
   # === Normalisations ===
   # Les fournisseurs d'identité ne garantissent pas la casse : sans ça, un agent enrôlé
   # en « Alice.Martin@… » serait refusé s'il se présente en « alice.martin@… ».

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -6,6 +6,8 @@ class Membership < ApplicationRecord
   # === Associations ===
   belongs_to :agent
   belongs_to :organization_link
+  # Pas de `dependent:` — la cascade est portée par la base.
+  has_many :process_accesses
 
   # === Enums ===
   # `validate: true` fait d'une valeur inconnue une erreur de validation là où Rails

--- a/app/models/membership.rb
+++ b/app/models/membership.rb
@@ -7,6 +7,19 @@ class Membership < ApplicationRecord
   belongs_to :agent
   belongs_to :organization_link
 
+  # === Enums ===
+  # `validate: true` fait d'une valeur inconnue une erreur de validation là où Rails
+  # lèverait une ArgumentError dès l'affectation.
+  enum :role, {member: "member", local_administrator: "local_administrator"}, validate: true
+
+  # === Normalisations ===
+  normalizes :phone_number, with: ->(value) { PhoneNumber.normalize(value) }
+
   # === Validations ===
   validates :agent_id, uniqueness: {scope: :organization_link_id}
+
+  # Ce que la normalisation n'a pas su mettre en forme est rejeté, pas effacé : l'import
+  # reçoit une erreur et peut réessayer sans le numéro plutôt que de perdre l'agent.
+  validates :phone_number, format: {with: PhoneNumber::E164_FORMAT}, allow_nil: true
+  validates :job_title, length: {maximum: 255}
 end

--- a/app/models/process_access.rb
+++ b/app/models/process_access.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+# Habilitation d'un agent, dans une organisation donnée, sur un processus de la V1 désigné
+# par son code. Référence, jamais une copie : la V1 n'expose aucun libellé.
+#
+# Ne vérifie pas que l'organisation est abonnée au processus — l'abonnement vit en V1 et
+# ce dépôt ne peut pas le contrôler. C'est un invariant qui engage les producteurs.
+class ProcessAccess < ApplicationRecord
+  # === Associations ===
+  # Pas de `dependent:` — la cascade est portée par la base.
+  belongs_to :membership
+
+  # === Normalisations ===
+  # Le code est un identifiant opaque : les codes ne sont pas tous en majuscules et
+  # certains portent des tirets, rabattre la casse en corromprait.
+  normalizes :process_code, with: ->(code) { code.strip }
+
+  # === Validations ===
+  # L'unicité est donc sensible à la casse, faute de savoir laquelle de deux formes vaut.
+  validates :process_code,
+    presence: true,
+    format: {with: /\A\S+\z/, allow_blank: true},
+    length: {maximum: 100},
+    uniqueness: {scope: :membership_id}
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -18,6 +18,8 @@ fr:
       membership/roles:
         member: Agent
         local_administrator: Administrateur local
+      process_access:
+        process_code: Code du processus
     errors:
       models:
         organization_link:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -11,6 +11,13 @@ fr:
       agent/civilities:
         mr: M.
         ms: Mme
+      membership:
+        role: Rôle
+        job_title: Fonction
+        phone_number: Téléphone
+      membership/roles:
+        member: Agent
+        local_administrator: Administrateur local
     errors:
       models:
         organization_link:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -3,6 +3,14 @@ fr:
   tagline: Plateforme d'échange sécurisé de fichiers entre administrations
 
   activerecord:
+    attributes:
+      agent:
+        civility: Civilité
+      # Libellés des valeurs de l'enum : `human_attribute_name("civilities.mr")` résout la
+      # clé pointée en `agent/civilities.mr`, d'où la barre oblique.
+      agent/civilities:
+        mr: M.
+        ms: Mme
     errors:
       models:
         organization_link:

--- a/db/migrate/20260805135858_add_civility_to_agents.rb
+++ b/db/migrate/20260805135858_add_civility_to_agents.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+# Chaîne et non type PostgreSQL, contrairement au rôle du rattachement : une civilité fausse
+# est un défaut d'affichage, pas un privilège usurpé.
+class AddCivilityToAgents < ActiveRecord::Migration[8.1]
+  def change
+    add_column :agents, :civility, :string
+  end
+end

--- a/db/migrate/20260805141431_add_profile_attributes_to_memberships.rb
+++ b/db/migrate/20260805141431_add_profile_attributes_to_memberships.rb
@@ -1,0 +1,14 @@
+# frozen_string_literal: true
+
+class AddProfileAttributesToMemberships < ActiveRecord::Migration[8.1]
+  def change
+    create_enum "membership_role", ["member", "local_administrator"]
+
+    # Type PostgreSQL et non simple validation : les écrivains de cette colonne sont
+    # extérieurs au dépôt et ne passent pas tous par ActiveRecord.
+    add_column :memberships, :role, :enum, enum_type: "membership_role",
+      null: false, default: "member"
+    add_column :memberships, :job_title, :string
+    add_column :memberships, :phone_number, :string
+  end
+end

--- a/db/migrate/20260805141910_create_process_accesses.rb
+++ b/db/migrate/20260805141910_create_process_accesses.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+class CreateProcessAccesses < ActiveRecord::Migration[8.1]
+  def change
+    create_table :process_accesses, id: :uuid, default: -> { "uuidv7()" } do |t|
+      # Cascade en base plutôt que `dependent:` : une habilitation ne doit pas survivre à
+      # son rattachement, y compris quand la suppression ne passe pas par Rails.
+      t.references :membership, type: :uuid, null: false, index: false,
+        foreign_key: {on_delete: :cascade}
+      t.string :process_code, null: false
+
+      t.timestamps
+    end
+
+    # L'index commence par membership_id : il sert aussi les recherches par rattachement,
+    # d'où `index: false` ci-dessus.
+    add_index :process_accesses, [:membership_id, :process_code], unique: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_141431) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_141910) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -97,6 +97,14 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_141431) do
     t.index ["siret"], name: "index_organizations_on_siret", unique: true
   end
 
+  create_table "process_accesses", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.datetime "created_at", null: false
+    t.uuid "membership_id", null: false
+    t.string "process_code", null: false
+    t.datetime "updated_at", null: false
+    t.index ["membership_id", "process_code"], name: "index_process_accesses_on_membership_id_and_process_code", unique: true
+  end
+
   create_table "provider_sessions", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.string "acr"
     t.string "amr", default: [], null: false, array: true
@@ -131,6 +139,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_141431) do
   add_foreign_key "memberships", "organization_links"
   add_foreign_key "notifications", "data_packages", on_delete: :cascade
   add_foreign_key "notifications", "subscriptions", on_delete: :restrict
+  add_foreign_key "process_accesses", "memberships", on_delete: :cascade
   add_foreign_key "provider_sessions", "memberships", on_delete: :cascade
   add_foreign_key "subscriptions", "data_streams", on_delete: :cascade
   add_foreign_key "subscriptions", "organizations", on_delete: :cascade

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,13 +10,14 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_05_135858) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_141431) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
   # Custom types defined in this database.
   # Note that some types may not work with other database engines. Be careful if changing database.
   create_enum "data_package_state", ["draft", "transmitted", "acknowledged"]
+  create_enum "membership_role", ["member", "local_administrator"]
 
   create_table "agents", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.string "civility"
@@ -59,7 +60,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_05_135858) do
   create_table "memberships", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
     t.uuid "agent_id", null: false
     t.datetime "created_at", null: false
+    t.string "job_title"
     t.uuid "organization_link_id", null: false
+    t.string "phone_number"
+    t.enum "role", default: "member", null: false, enum_type: "membership_role"
     t.datetime "updated_at", null: false
     t.index ["agent_id", "organization_link_id"], name: "index_memberships_on_agent_id_and_organization_link_id", unique: true
     t.index ["agent_id"], name: "index_memberships_on_agent_id"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_08_04_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_08_05_135858) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
 
@@ -19,6 +19,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_08_04_120000) do
   create_enum "data_package_state", ["draft", "transmitted", "acknowledged"]
 
   create_table "agents", id: :uuid, default: -> { "uuidv7()" }, force: :cascade do |t|
+    t.string "civility"
     t.datetime "created_at", null: false
     t.string "email", null: false
     t.string "first_name"

--- a/lib/phone_number.rb
+++ b/lib/phone_number.rb
@@ -1,0 +1,52 @@
+# frozen_string_literal: true
+
+# Normalisation E.164 des numéros de téléphone français. Fonctions pures, sans dépendance :
+# le besoin est borné aux numéros d'administrations françaises, et une gem de plan de
+# numérotation mondial serait payée pour ce qu'on n'en utilise pas. Le prix de ce choix est
+# double et assumé — la table des préfixes ultramarins est tenue à la main, et
+# l'attribuabilité n'est pas vérifiée : « +33 1 99 99 99 99 » a la bonne forme et n'est
+# attribué à personne.
+module PhoneNumber
+  # Forme finale acceptée en base. Bornes E.164 : indicatif compris, un numéro ne dépasse
+  # pas quinze chiffres.
+  E164_FORMAT = /\A\+\d{8,15}\z/
+
+  # La règle métropolitaine « on remplace le 0 par +33 » produirait +33262… là où le numéro
+  # est +262 262…. Fixes et mobiles ne partagent pas leur préfixe, d'où deux séries par
+  # territoire. Les collectivités du Pacifique (+687, +689, +681) et Saint-Pierre-et-Miquelon
+  # (+508) relèvent de plans distincts — six ou huit chiffres, sans zéro initial : elles ne
+  # ressemblent pas à un numéro métropolitain et se saisissent en forme internationale.
+  OVERSEAS_PREFIXES = {
+    "262" => "+262", "263" => "+262", "692" => "+262", "693" => "+262", # Réunion
+    "269" => "+262", "639" => "+262",                                   # Mayotte
+    "590" => "+590", "690" => "+590", "691" => "+590",                  # Guadeloupe, Saint-Martin, Saint-Barthélemy
+    "594" => "+594", "694" => "+594",                                   # Guyane
+    "596" => "+596", "696" => "+596", "697" => "+596"                   # Martinique
+  }.freeze
+
+  # Séparateurs de saisie : espaces (insécables compris), points, tirets, parenthèses.
+  SEPARATORS = /[[:space:].\-()]/
+
+  # Indicatif national des numéros imprimés en forme internationale — « +33 (0)1 42 … ».
+  # Il se retire avant les séparateurs : sinon les parenthèses tombent d'abord et il reste
+  # un 0 collé à l'indicatif.
+  TRUNK_CODE = "(0)"
+
+  # Un numéro national français : le zéro initial suivi de neuf chiffres.
+  NATIONAL_FORMAT = /\A0\d{9}\z/
+
+  module_function
+
+  # Rend la forme E.164 quand elle est déductible, et la valeur nettoyée sinon — jamais nil
+  # pour une saisie non vide. C'est la validation appelante qui rejette ce qui n'a pas pu
+  # être normalisé : effacer ici perdrait la donnée sans que le producteur le sache.
+  def normalize(raw)
+    return nil if raw.blank?
+
+    cleaned = raw.gsub(TRUNK_CODE, "").gsub(SEPARATORS, "").sub(/\A00/, "+")
+    return cleaned unless cleaned.match?(NATIONAL_FORMAT)
+
+    national = cleaned.delete_prefix("0")
+    "#{OVERSEAS_PREFIXES.fetch(national[0, 3], "+33")}#{national}"
+  end
+end

--- a/spec/factories/memberships.rb
+++ b/spec/factories/memberships.rb
@@ -2,5 +2,9 @@ FactoryBot.define do
   factory :membership do
     agent
     organization_link
+
+    trait :local_administrator do
+      role { "local_administrator" }
+    end
   end
 end

--- a/spec/factories/process_accesses.rb
+++ b/spec/factories/process_accesses.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :process_access do
+    membership
+    sequence(:process_code) { |n| "PROC-#{n}" }
+  end
+end

--- a/spec/lib/phone_number_spec.rb
+++ b/spec/lib/phone_number_spec.rb
@@ -1,0 +1,65 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe PhoneNumber do
+  describe ".normalize" do
+    it "brings metropolitan numbers to E.164, whatever the separators" do
+      expect(described_class.normalize("01 42 76 20 00")).to eq("+33142762000")
+      expect(described_class.normalize("01.42.76.20.00")).to eq("+33142762000")
+      expect(described_class.normalize("01-42-76-20-00")).to eq("+33142762000")
+      expect(described_class.normalize("0142762000")).to eq("+33142762000")
+      expect(described_class.normalize("06 12 34 56 78")).to eq("+33612345678")
+    end
+
+    it "reads the international forms an agent may paste" do
+      expect(described_class.normalize("+33 1 42 76 20 00")).to eq("+33142762000")
+      expect(described_class.normalize("0033142762000")).to eq("+33142762000")
+      # Le (0) imprimé ne fait pas partie du numéro : le garder produirait
+      # +330142762000, qui a la bonne forme sans être le bon numéro.
+      expect(described_class.normalize("+33 (0)1 42 76 20 00")).to eq("+33142762000")
+    end
+
+    it "gives overseas landlines their own country code, not +33" do
+      expect(described_class.normalize("0262 12 34 56")).to eq("+262262123456")
+      expect(described_class.normalize("0263 12 34 56")).to eq("+262263123456")
+      expect(described_class.normalize("0269 12 34 56")).to eq("+262269123456")
+      expect(described_class.normalize("0590 12 34 56")).to eq("+590590123456")
+      expect(described_class.normalize("0594 12 34 56")).to eq("+594594123456")
+      expect(described_class.normalize("0596 12 34 56")).to eq("+596596123456")
+    end
+
+    # Les mobiles ultramarins ne partagent pas le préfixe des fixes : les omettre de la
+    # table enverrait un numéro réunionnais sur +33.
+    it "gives overseas mobiles their own country code too" do
+      expect(described_class.normalize("0692 12 34 56")).to eq("+262692123456")
+      expect(described_class.normalize("0693 12 34 56")).to eq("+262693123456")
+      expect(described_class.normalize("0639 12 34 56")).to eq("+262639123456")
+      expect(described_class.normalize("0690 12 34 56")).to eq("+590690123456")
+      expect(described_class.normalize("0691 12 34 56")).to eq("+590691123456")
+      expect(described_class.normalize("0694 12 34 56")).to eq("+594694123456")
+      expect(described_class.normalize("0696 12 34 56")).to eq("+596696123456")
+      expect(described_class.normalize("0697 12 34 56")).to eq("+596697123456")
+    end
+
+    # Nouvelle-Calédonie : plan de numérotation distinct, six chiffres sans zéro initial.
+    # Ces numéros se saisissent en forme internationale et traversent sans transformation.
+    it "leaves numbers from the Pacific collectivities untouched" do
+      expect(described_class.normalize("+687 12 34 56")).to eq("+687123456")
+    end
+
+    it "has nothing to normalize in a blank value" do
+      expect(described_class.normalize(nil)).to be_nil
+      expect(described_class.normalize("")).to be_nil
+      expect(described_class.normalize("   ")).to be_nil
+    end
+
+    # Ce que la normalisation ne sait pas mettre en forme, elle le rend nettoyé plutôt que
+    # de l'effacer : c'est la validation qui rejettera, et le producteur saura ce qu'il a
+    # écrit. Effacer en silence perdrait la donnée sans le signaler à personne.
+    it "returns what it cannot normalize instead of erasing it" do
+      expect(described_class.normalize("12345")).to eq("12345")
+      expect(described_class.normalize("01 42")).to eq("0142")
+    end
+  end
+end

--- a/spec/models/agent_spec.rb
+++ b/spec/models/agent_spec.rb
@@ -17,6 +17,25 @@ RSpec.describe Agent, type: :model do
     it { is_expected.to validate_uniqueness_of(:email).ignoring_case_sensitivity }
   end
 
+  describe "civility" do
+    # Facultative : l'absence est un état légitime — l'import ne doit pas échouer sur un
+    # stock V1 incomplet, et personne n'est forcé de se déclarer.
+    it "accepts the closed list and nothing else, absence included" do
+      expect(build(:agent, civility: "mr")).to be_valid
+      expect(build(:agent, civility: "ms")).to be_valid
+      expect(build(:agent, civility: nil)).to be_valid
+      expect(build(:agent, civility: "docteur")).not_to be_valid
+    end
+  end
+
+  describe "labels" do
+    it "names the attribute and each of its values in French" do
+      expect(described_class.human_attribute_name(:civility)).to eq("Civilité")
+      expect(described_class.human_attribute_name("civilities.mr")).to eq("M.")
+      expect(described_class.human_attribute_name("civilities.ms")).to eq("Mme")
+    end
+  end
+
   describe "associations" do
     subject { build(:agent) }
 

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -8,6 +8,7 @@ RSpec.describe Membership, type: :model do
 
     it { is_expected.to belong_to(:agent) }
     it { is_expected.to belong_to(:organization_link) }
+    it { is_expected.to have_many(:process_accesses) }
   end
 
   describe "validations" do

--- a/spec/models/membership_spec.rb
+++ b/spec/models/membership_spec.rb
@@ -22,4 +22,56 @@ RSpec.describe Membership, type: :model do
         .ignoring_case_sensitivity
     }
   end
+
+  describe "role" do
+    # Le moindre privilège est le défaut : un rôle non accordé n'est pas administrateur.
+    it "makes a membership a plain member until told otherwise" do
+      expect(create(:membership)).to be_member
+      expect(create(:membership, :local_administrator)).to be_local_administrator
+    end
+
+    it "refuses a role outside the closed list" do
+      expect(build(:membership, role: "national_administrator")).not_to be_valid
+    end
+  end
+
+  describe "phone_number" do
+    it "stores what an agent types in its international form" do
+      expect(create(:membership, phone_number: "01 42 76 20 00").phone_number)
+        .to eq("+33142762000")
+      expect(create(:membership, phone_number: "0692 12 34 56").phone_number)
+        .to eq("+262692123456")
+    end
+
+    # Rejeter plutôt qu'effacer : un numéro perdu en silence ne serait signalé à personne.
+    it "rejects a number it could not bring to international form" do
+      membership = build(:membership, phone_number: "12345")
+
+      expect(membership).not_to be_valid
+      expect(membership.errors[:phone_number]).to be_present
+    end
+
+    it "accepts having no phone number at all" do
+      expect(build(:membership, phone_number: nil)).to be_valid
+      expect(build(:membership, phone_number: "")).to be_valid
+    end
+  end
+
+  describe "job_title" do
+    it "bounds the job title" do
+      expect(build(:membership, job_title: "a" * 255)).to be_valid
+      expect(build(:membership, job_title: "a" * 256)).not_to be_valid
+    end
+  end
+
+  describe "labels" do
+    it "names the attributes and each role in French" do
+      expect(described_class.human_attribute_name(:role)).to eq("Rôle")
+      expect(described_class.human_attribute_name(:job_title)).to eq("Fonction")
+      expect(described_class.human_attribute_name(:phone_number)).to eq("Téléphone")
+      expect(described_class.human_attribute_name("roles.member")).to eq("Agent")
+      expect(described_class.human_attribute_name("roles.local_administrator"))
+        .to eq("Administrateur local")
+    end
+  end
 end

--- a/spec/models/process_access_spec.rb
+++ b/spec/models/process_access_spec.rb
@@ -1,0 +1,55 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe ProcessAccess, type: :model do
+  describe "associations" do
+    subject { build(:process_access) }
+
+    it { is_expected.to belong_to(:membership) }
+  end
+
+  describe "process_code" do
+    it "keeps the code exactly as the V1 referential spells it" do
+      expect(create(:process_access, process_code: "certdc-v2").process_code)
+        .to eq("certdc-v2")
+      expect(create(:process_access, process_code: "  CERTDC  ").process_code)
+        .to eq("CERTDC")
+    end
+
+    it "refuses a code carrying an inner space" do
+      expect(build(:process_access, process_code: "CERT DC")).not_to be_valid
+    end
+
+    it "bounds the code length" do
+      expect(build(:process_access, process_code: "A" * 100)).to be_valid
+      expect(build(:process_access, process_code: "A" * 101)).not_to be_valid
+    end
+
+    it "tells two codes apart when only their case differs" do
+      membership = create(:membership)
+      create(:process_access, membership:, process_code: "CERTDC")
+
+      expect(build(:process_access, membership:, process_code: "certdc")).to be_valid
+      expect(build(:process_access, membership:, process_code: "CERTDC")).not_to be_valid
+    end
+  end
+
+  describe "cascade" do
+    # La garantie est en base : `delete_all` ne déclenche aucun callback, et c'est
+    # précisément le cas qu'un `dependent: :destroy` laisserait filer.
+    it "disappears with the membership it was granted under" do
+      process_access = create(:process_access)
+
+      Membership.where(id: process_access.membership_id).delete_all
+
+      expect(ProcessAccess.exists?(process_access.id)).to be(false)
+    end
+  end
+
+  describe "labels" do
+    it "names the attribute in French" do
+      expect(described_class.human_attribute_name(:process_code)).to eq("Code du processus")
+    end
+  end
+end


### PR DESCRIPTION
## Ce que fait cette PR

Un rattachement ne disait qu'une chose : cet agent appartient à cette organisation. Il ne disait pas s'il y est administrateur, sur quels processus il travaille, quelle fonction il occupe ni comment le joindre — toutes choses que la V1 tient déjà dans Keycloak et que l'import du stock perdrait faute d'un endroit où les déposer.

Cette branche ouvre cette place. **Elle n'ouvre aucun comportement** : aucune vue ne lit ces données, aucun code de ce dépôt ne les écrit. Sa valeur est d'être le contrat que l'import et le producteur externe honoreront, et de rendre possible l'exigence de second facteur des comptes à privilèges.

### Ce qui décrit la personne, ce qui décrit le poste

La civilité suit l'agent. La fonction, le téléphone et le rôle suivent le **rattachement** : un agent rattaché à deux organisations y occupe deux fonctions et peut n'être administrateur que dans l'une.

### Le rôle est garanti par la base, la civilité par Rails

Le rôle porte un type PostgreSQL (`membership_role`), pas seulement une validation. Les écrivains de cette colonne sont extérieurs à ce dépôt et rien ne garantit qu'ils passent par ActiveRecord — or c'est le rôle qui décide qui est administrateur. Même raisonnement qu'en #116 pour `on_delete: :cascade` : la garantie doit tenir quand le SQL ne passe pas par le modèle. Le défaut `member` porte le moindre privilège au niveau de la colonne.

La civilité, elle, reste une chaîne validée par Rails. La garantie en base se paie et doit se mériter : une civilité fausse est un défaut d'affichage, pas un privilège usurpé — et c'est justement la liste dont on sait qu'elle bougera.

### Les habilitations référencent, elles ne recopient pas

Table de jointure `process_accesses`, index unique sur le couple, cascade **en base** sans `dependent:` — une habilitation ne doit pas survivre à son rattachement, y compris quand celui-ci disparaît par `delete_all`. Le spec le vérifie par `delete_all` et non par `destroy` : avec un `destroy`, il passerait au vert même sans la contrainte.

Le code de processus est un identifiant opaque de la V1, stocké tel quel. Les codes ne sont pas tous en majuscules et certains portent des tirets : rabattre la casse en corromprait. L'unicité est donc sensible à la casse, faute de pouvoir décider laquelle de deux formes serait la bonne. La validation n'exclut que les blancs et borne la longueur — deviner le jeu de caractères ferait refuser un code légitime.

### Les téléphones sans dépendance nouvelle

`PhoneNumber` normalise en E.164 sans gem de plan de numérotation mondial. Le prix est explicite : quatorze préfixes ultramarins tenus à la main — `0692` doit donner `+262692…`, pas `+33692…`, et les mobiles ne partagent pas le préfixe des fixes — et l'abandon du contrôle d'attribuabilité, `+33 1 99 99 99 99` ayant la bonne forme sans être attribué.

Ce qui n'est pas normalisable est **rejeté, pas effacé**. Un numéro effacé en silence ne serait signalé à personne ; une erreur de validation permet à l'import de réessayer sans le numéro et de garder l'agent. Perdre un rattachement sur un numéro mal saisi serait un mauvais échange.

## Notes de déploiement

Trois migrations, **aucune donnée à migrer** : les colonnes concernées n'existaient pas et le portail n'est pas en production. Aucune nouvelle variable d'environnement.

## Points à trancher en équipe

Aucun ne bloque cette branche.

1. **Placement des modèles mono-module.** `ProcessAccess` rejoint `ProviderSession` dans la pile ouverte par #116. Ici le placement en `::` est contraint, pas choisi : `Membership` y vit et déclare `has_many :process_accesses`, or un modèle de `::` ne peut pas référencer `::Portail`. L'arbitrage gagne à se prendre une fois pour les cinq modèles.

2. **Troisième valeur de civilité.** Différée volontairement : personne ne se déclare aujourd'hui, les données arrivant par l'import et les producteurs externes. Une valeur qu'aucune source ne peut produire serait du code mort qui fuiterait dans le contrat d'import. À trancher au premier écran de saisie, avec les personnes concernées — aucun référentiel administratif français ne fournit de terme neutre officiel.

3. **Complétude du stock V1** sur la civilité, la fonction et le téléphone. Elle décide de ce que l'import déposera réellement. À confirmer avant l'import.

## Vérifications

`bin/ci` verte : 309 exemples, 0 échec, Brakeman 0, couverture 99 %.

**Rien à vérifier manuellement** : aucune interface, aucun parcours. La seule surface visible est l'intitulé français des attributs et des valeurs, couvert par des specs — `human_attribute_name` résout une clé pointée en `agent/civilities.mr`, avec une barre oblique, et un test fixe cette convention pour que personne ne la « corrige » en imbriquant le YAML.

## Refs

- Ticket #650 — *Le portail V2 n'a nulle part où recevoir ce que la V1 sait de ses agents*
- Débloque le ticket #619 (second facteur des comptes à privilèges), dont le périmètre a été révisé pour y inclure les agents habilités sur un processus sensible
- Contrat à honorer par les tickets #448 (import du stock) et #618 (producteur externe)
