### PR TITLE
feat(auth): exiger un second facteur des comptes à privilèges

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,3 +12,9 @@ PROCONNECT_POST_LOGOUT_REDIRECT_URI=http://localhost:3000/
 
 ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=
 ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=
+
+# Codes des processus dont l'accès exige un second facteur, séparés par des virgules.
+# Les vraies valeurs viennent d'ansible_deploy — jamais dans ce dépôt, qui est public.
+# Déclarée mais vide = aucun processus sensible, et c'est un choix assumé ; absente,
+# l'application refuse de démarrer.
+SENSITIVE_PROCESS_CODES=

--- a/.env.test
+++ b/.env.test
@@ -16,3 +16,4 @@ PROCONNECT_REDIRECT_URI=http://www.example.com/auth/proconnect/callback
 PROCONNECT_POST_LOGOUT_REDIRECT_URI=http://www.example.com/
 ACTIVE_RECORD_ENCRYPTION_PRIMARY_KEY=cle-de-test-non-secrete-depot-public
 ACTIVE_RECORD_ENCRYPTION_KEY_DERIVATION_SALT=sel-de-test-non-secret-depot-public
+SENSITIVE_PROCESS_CODES=DEMO_SENSIBLE

--- a/app/controllers/concerns/portail/authentication.rb
+++ b/app/controllers/concerns/portail/authentication.rb
@@ -11,6 +11,7 @@ module Portail
     included do
       helper_method :current_agent, :agent_signed_in?, :current_membership
       before_action :expire_stale_session!
+      before_action :enforce_second_factor!
       before_action :require_authentication
     end
 
@@ -43,7 +44,9 @@ module Portail
     def find_session_by_cookie
       return @session_in_cookie if defined?(@session_in_cookie)
 
-      @session_in_cookie = ProviderSession.includes(membership: :agent)
+      # Les habilitations viennent avec le reste : le garde du second facteur les lit à
+      # chaque requête, autant les charger dans la requête déjà faite.
+      @session_in_cookie = ProviderSession.includes(membership: [:agent, :process_accesses])
         .find_by(id: session[:provider_session_id])
     end
 
@@ -62,6 +65,22 @@ module Portail
       remove_instance_variable(:@session_in_cookie)
       Current.provider_session = nil
       reset_session
+    end
+
+    # Relu à chaque requête plutôt que porté par le cookie : un rattachement peut devenir
+    # à privilèges pendant la session. On éjecte sans élever — détourner une requête
+    # quelconque vers ProConnect donnerait un retour qui ne sait plus où renvoyer l'agent.
+    def enforce_second_factor!
+      record = find_session_by_cookie
+      return unless record&.granted?
+      return if Portail::SecondFactor.satisfied?(record.membership, record.acr)
+
+      terminate_session
+      # Après `terminate_session` : son reset_session effacerait un marqueur posé avant.
+      # L'agent repart donc directement sur l'élévation plutôt que sur un accueil qui ne
+      # lui dirait pas quoi faire.
+      session[:proconnect_step_up] = true
+      redirect_to step_up_path, alert: t("portail.sessions.second_factor_required")
     end
 
     def expire_stale_session!

--- a/app/controllers/portail/sessions_controller.rb
+++ b/app/controllers/portail/sessions_controller.rb
@@ -7,7 +7,7 @@ module Portail
 
     # Ouvert à tous, et chaque appel déclenche deux requêtes sortantes vers ProConnect —
     # échange du code puis userinfo. Sans limite, on se laisse transformer en amplificateur.
-    rate_limit to: 10, within: 3.minutes, only: :create, with: -> { head :too_many_requests }
+    rate_limit to: 10, within: 1.minute, only: :create, with: -> { head :too_many_requests }
 
     # Motifs qui ne portent aucun jugement sur l'agent : rien à lui expliquer sur son
     # compte, la page d'échec générique suffit.
@@ -18,14 +18,20 @@ module Portail
         id_token: auth_hash.credentials.id_token,
         nonce: auth_hash.extra.nonce,
         info: auth_hash.info,
-        siret: auth_hash.extra.raw_info&.dig("siret")
+        siret: auth_hash.extra.raw_info&.dig("siret"),
+        step_up_attempted: session[:proconnect_step_up]
       )
 
       if result.success?
-        # Lue avant : `terminate_session` réinitialise la session et l'effacerait.
+        # Lus avant : `terminate_session` réinitialise la session et les effacerait.
         target = after_authentication_url
+        remember_device = session[:proconnect_remember_device]
         adopt_session(result.provider_session)
+        remember_device!(remember_device, result.membership)
         redirect_to target, notice: t(".signed_in")
+      elsif result.error == :step_up_required
+        session[:proconnect_step_up] = true
+        redirect_to step_up_path
       elsif TECHNICAL_FAILURES.include?(result.error)
         redirect_to auth_failure_path
       else
@@ -53,6 +59,12 @@ module Portail
       render status: :forbidden
     end
 
+    # Le marqueur porte à la fois la page et sa raison d'être : sans lui, l'adresse est
+    # arrivée par un lien ou un signet, et il n'y a rien à élever.
+    def step_up
+      redirect_to root_path unless session[:proconnect_step_up]
+    end
+
     # Sert la déconnexion d'un agent entré comme l'abandon d'une tentative refusée : dans
     # les deux cas on ferme chez nous d'abord, pour que ProConnect injoignable ne retienne
     # jamais personne.
@@ -73,6 +85,22 @@ module Portail
 
     def auth_hash
       request.env["omniauth.auth"]
+    end
+
+    # Mémorise que ce navigateur sert à un compte à privilèges, pour lui exiger la MFA dès
+    # la première autorisation et lui épargner l'aller-retour d'élévation. Aucune identité
+    # dedans, et il ne peut qu'élever l'exigence — d'où l'absence de signature.
+    # `nil` signifie que la question n'a pas été posée : on laisse alors le choix précédent.
+    def remember_device!(choice, membership)
+      return if choice.nil? || !Portail::SecondFactor.required_for?(membership)
+
+      if choice
+        cookies[OmniAuth::Strategies::ProconnectHardened::PRIVILEGED_DEVICE_COOKIE] = {
+          value: "1", expires: 1.year, httponly: true, same_site: :lax, secure: request.ssl?
+        }
+      else
+        cookies.delete(OmniAuth::Strategies::ProconnectHardened::PRIVILEGED_DEVICE_COOKIE)
+      end
     end
 
     # Sans adresse, la page de refus n'aurait rien à montrer — la page d'échec vaut mieux

--- a/app/controllers/portail/sessions_controller.rb
+++ b/app/controllers/portail/sessions_controller.rb
@@ -5,6 +5,11 @@ module Portail
     # La surface d'authentification elle-même : s'y authentifier ne peut être un prérequis.
     allow_unauthenticated_access
 
+    # Entrer et sortir doit rester possible quels que soient les droits : un agent dont le
+    # rattachement vient de changer doit pouvoir se déconnecter, et fermer aussi sa session
+    # ProConnect.
+    skip_before_action :enforce_second_factor!
+
     # Ouvert à tous, et chaque appel déclenche deux requêtes sortantes vers ProConnect —
     # échange du code puis userinfo. Sans limite, on se laisse transformer en amplificateur.
     rate_limit to: 10, within: 1.minute, only: :create, with: -> { head :too_many_requests }
@@ -92,7 +97,12 @@ module Portail
     # dedans, et il ne peut qu'élever l'exigence — d'où l'absence de signature.
     # `nil` signifie que la question n'a pas été posée : on laisse alors le choix précédent.
     def remember_device!(choice, membership)
-      return if choice.nil? || !Portail::SecondFactor.required_for?(membership)
+      # Un agent qui n'y est plus soumis efface le marquage : sans ça, un rattachement
+      # rétrogradé laisserait le navigateur réclamer la MFA pour toujours, et l'agent ne
+      # reverrait jamais la case pour la décocher.
+      return cookies.delete(OmniAuth::Strategies::ProconnectHardened::PRIVILEGED_DEVICE_COOKIE) unless
+        Portail::SecondFactor.required_for?(membership)
+      return if choice.nil?
 
       if choice
         cookies[OmniAuth::Strategies::ProconnectHardened::PRIVILEGED_DEVICE_COOKIE] = {

--- a/app/interactors/portail/sessions/create.rb
+++ b/app/interactors/portail/sessions/create.rb
@@ -8,7 +8,7 @@ module Portail
       # Les deux dernières étapes écrivent : rien ne l'est tant que l'accès n'est pas
       # acquis, c'est-à-dire tant que FindMembership n'a pas conclu.
       organize VerifyIdToken, CheckAuthenticationLevel, FindAgent, FindMembership,
-        SyncAgentIdentity, OpenSession
+        CheckSecondFactor, SyncAgentIdentity, OpenSession
     end
   end
 end

--- a/app/interactors/portail/sessions/create/check_second_factor.rb
+++ b/app/interactors/portail/sessions/create/check_second_factor.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Portail
+  module Sessions
+    class Create
+      # Le niveau est lu dans le jeton vérifié, jamais ailleurs : ce qui a été demandé au
+      # départ ne prouve rien de ce qui a été atteint.
+      class CheckSecondFactor
+        include Interactor
+
+        def call
+          return if SecondFactor.satisfied?(context.membership, context.claims[:acr])
+
+          # Une seule élévation : redemander enverrait l'agent en boucle entre les deux
+          # services.
+          context.fail!(error: context.step_up_attempted ? :second_factor_required : :step_up_required)
+        end
+      end
+    end
+  end
+end

--- a/app/views/portail/sessions/step_up.html.erb
+++ b/app/views/portail/sessions/step_up.html.erb
@@ -1,0 +1,37 @@
+<% content_for :title, t("portail.sessions.step_up.title") %>
+
+<div class="fr-grid-row fr-grid-row--center">
+  <div class="fr-col-12 fr-col-md-8">
+    <h1><%= t("portail.sessions.step_up.heading") %></h1>
+    <p class="fr-text--lead"><%= t("portail.sessions.step_up.body") %></p>
+
+    <%# ProConnect réidentifie l'agent et prend en charge l'enrôlement : le prévenir ici
+        évite qu'il croie s'être trompé ou que la connexion ait échoué. %>
+    <p><%= t("portail.sessions.step_up.what_to_expect") %></p>
+
+    <%# L'agent quitte le portail pour un service tiers puis y revient : sans consigne
+        explicite, il peut s'arrêter en chemin en croyant en avoir fini. %>
+    <p><%= t("portail.sessions.step_up.call_to_action") %></p>
+
+    <%# Pas d'auto-soumission : le clic est le moment où l'agent comprend pourquoi il
+        repart vers ProConnect. Hors Turbo, la cible étant un hôte externe. %>
+    <%= form_with url: "/auth/proconnect", method: :post, data: {turbo: false} do |form| %>
+      <%# Markup DSFR : libellé court dans le label, explication dans un fr-hint-text
+          à l'intérieur du label — c'est lui qui reçoit la pleine largeur, un libellé
+          long posé à plat désaligne la case. %>
+      <div class="fr-mb-4w">
+        <div class="fr-checkbox-group">
+          <%= form.check_box :remember_device, checked: true, class: "fr-checkbox" %>
+          <%= form.label :remember_device, class: "fr-label" do %>
+            <%= t("portail.sessions.step_up.remember_device") %>
+            <span class="fr-hint-text"><%= t("portail.sessions.step_up.remember_device_hint") %></span>
+          <% end %>
+        </div>
+      </div>
+
+      <%= form.button class: "proconnect-button" do %>
+        <span class="proconnect-sr-only"><%= t("portail.sessions.proconnect_button.label") %></span>
+      <% end %>
+    <% end %>
+  </div>
+</div>

--- a/config/initializers/sensitive_processes.rb
+++ b/config/initializers/sensitive_processes.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+# Une liste vide est un choix légitime, mais elle doit être explicite : une variable oubliée
+# produirait le même comportement — plus personne n'est soumis au second facteur au titre
+# d'un processus — sans que rien ne le dise.
+#
+# SECRET_KEY_BASE_DUMMY marque la précompilation des assets, qui démarre l'application sans
+# aucun secret : la variable est requise pour servir, pas pour construire l'image.
+unless ENV.key?("SENSITIVE_PROCESS_CODES") || ENV["SECRET_KEY_BASE_DUMMY"].present?
+  raise "SENSITIVE_PROCESS_CODES est requise — voir .env.example"
+end

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -64,6 +64,7 @@ fr:
         info: Qu'est-ce que ProConnect ?
         info_title: Qu'est-ce que ProConnect ? - nouvelle fenêtre
       expired: Votre session a expiré, reconnectez-vous pour continuer.
+      second_factor_required: "Vos droits ont changé : votre compte exige désormais une authentification renforcée."
       step_up:
         title: Authentification renforcée — HubEE
         heading: Une authentification renforcée est requise

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -64,6 +64,14 @@ fr:
         info: Qu'est-ce que ProConnect ?
         info_title: Qu'est-ce que ProConnect ? - nouvelle fenêtre
       expired: Votre session a expiré, reconnectez-vous pour continuer.
+      step_up:
+        title: Authentification renforcée — HubEE
+        heading: Une authentification renforcée est requise
+        body: "Votre compte donne accès à des fonctions sensibles : y entrer demande un second facteur d'authentification, en plus de votre mot de passe."
+        what_to_expect: ProConnect va vous redemander votre adresse électronique, puis un code fourni par votre méthode de double authentification — et vous guidera pour en mettre une en place si vous n'en avez pas encore. C'est normal, votre connexion n'a pas échoué.
+        call_to_action: Cliquez sur le bouton ci-dessous et suivez les étapes jusqu'au bout. Vous reviendrez ensuite automatiquement sur HubEE.
+        remember_device: Se souvenir de cet appareil
+        remember_device_hint: La double authentification vous sera demandée dès la connexion suivante, sans cette étape intermédiaire. À décocher si ce poste est partagé avec d'autres agents.
       create:
         signed_in: Vous êtes connecté.
       destroy:
@@ -84,6 +92,9 @@ fr:
         organization_mismatch:
           heading: Vous n'êtes pas autorisé au titre de cette organisation
           body: "Aucun rattachement ne vous autorise à entrer au titre de %{organization}. Si vous appartenez à plusieurs organisations, réessayez avec une autre ; sinon, contactez votre administration."
+        second_factor_required:
+          heading: Votre compte exige une authentification à deux facteurs
+          body: Votre compte donne accès à des fonctions sensibles et n'a pas pu être protégé par un second facteur. Reconnectez-vous et allez au bout de l'étape proposée par ProConnect, qui prend en charge son installation.
         email_mismatch:
           heading: Votre adresse ne correspond pas à votre compte
           body: "L'adresse de votre compte ProConnect n'est plus celle enregistrée par HubEE. Par précaution, l'accès est suspendu : demandez sa mise à jour à votre administration, puis reconnectez-vous."

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -47,5 +47,8 @@ Rails.application.routes.draw do
   # Le callback porte un code à usage unique : il redirige ici plutôt que de rendre le
   # refus, sinon la page ne serait ni rechargeable ni partageable.
   get "connexion/refusee", to: "portail/sessions#denied", as: :denied
+  # Même raison : rendre l'élévation au callback rejouerait le code à usage unique au
+  # moindre rechargement, et ProConnect répondrait 400.
+  get "connexion/second-facteur", to: "portail/sessions#step_up", as: :step_up
   delete "logout", to: "portail/sessions#destroy", as: :logout
 end

--- a/lib/omni_auth/strategies/proconnect_hardened.rb
+++ b/lib/omni_auth/strategies/proconnect_hardened.rb
@@ -44,7 +44,7 @@ module OmniAuth
             scope: options[:scope],
             state: store_new_state!,
             nonce: store_new_nonce!,
-            claims: {id_token: {amr: {essential: true}}}.to_json,
+            claims: requested_claims,
             # Sans `acr_values`, ProConnect n'émet aucun `acr` — le demander via `claims`
             # ne suffit pas — et CheckAuthenticationLevel refuserait alors tout le monde.
             # La valeur annonce notre minimum ; elle ne dispense pas de vérifier le niveau
@@ -52,6 +52,22 @@ module OmniAuth
             acr_values: MINIMUM_AUTHENTICATION_LEVEL
           )
         end
+      end
+
+      # Le second facteur se demande par `claims`, comme le prescrit la doc ProConnect —
+      # `acr_values` n'annonce qu'un plancher et n'oblige à rien. `essential: true` fait
+      # renvoyer une erreur si ProConnect ne peut pas satisfaire, plutôt qu'un niveau plus
+      # faible : `callback_phase` la lit déjà.
+      def requested_claims
+        claims = {id_token: {amr: {essential: true}}}
+        claims[:id_token][:acr] = {essential: true, values: Portail::SecondFactor::LEVELS} if stepping_up?
+        claims.to_json
+      end
+
+      # Marqué par le contrôleur au retour du premier callback. Jamais un paramètre de
+      # requête : c'est l'application qui décide du niveau exigé, pas l'appelant.
+      def stepping_up?
+        session["proconnect_step_up"].present?
       end
     end
   end

--- a/lib/omni_auth/strategies/proconnect_hardened.rb
+++ b/lib/omni_auth/strategies/proconnect_hardened.rb
@@ -16,6 +16,10 @@ module OmniAuth
       # accepte. Voir Portail::Sessions::Create::CheckAuthenticationLevel.
       MINIMUM_AUTHENTICATION_LEVEL = "eidas1"
 
+      # Posé par le contrôleur, relu ici. Le nom est partagé, la valeur ne l'est pas :
+      # ce cookie ne porte aucune identité, seulement « ce navigateur a déjà servi ».
+      PRIVILEGED_DEVICE_COOKIE = "hubee_second_factor_device"
+
       credentials do
         {id_token: session["omniauth.pc.id_token"]}
       end
@@ -29,6 +33,16 @@ module OmniAuth
       # parlent alors de décodage JWT là où il faudrait lire le refus lui-même.
       def callback_phase
         return fail!(request.params["error"]) if request.params["error"].present?
+
+        super
+      end
+
+      # La case n'existe que sur la page d'élévation : ailleurs, le paramètre est absent et
+      # le choix précédent doit être laissé intact plutôt qu'écrasé par un faux « non ».
+      def request_phase
+        if request.params.key?("remember_device")
+          session["proconnect_remember_device"] = request.params["remember_device"] == "1"
+        end
 
         super
       end
@@ -49,7 +63,7 @@ module OmniAuth
             # ne suffit pas — et CheckAuthenticationLevel refuserait alors tout le monde.
             # La valeur annonce notre minimum ; elle ne dispense pas de vérifier le niveau
             # réellement atteint au retour, seul contrôle qui fasse foi.
-            acr_values: MINIMUM_AUTHENTICATION_LEVEL
+            acr_values: requested_acr_values
           )
         end
       end
@@ -64,10 +78,22 @@ module OmniAuth
         claims.to_json
       end
 
-      # Marqué par le contrôleur au retour du premier callback. Jamais un paramètre de
-      # requête : c'est l'application qui décide du niveau exigé, pas l'appelant.
+      # Élevé en même temps que les claims : laisser `acr_values` au plancher enverrait
+      # deux consignes contradictoires — « il me faut du MFA » et « eidas1 me convient ».
+      def requested_acr_values
+        return MINIMUM_AUTHENTICATION_LEVEL unless stepping_up?
+
+        Portail::SecondFactor::LEVELS.join(" ")
+      end
+
+      # Deux origines : le marqueur posé par le contrôleur au retour du premier callback,
+      # et le cookie d'un navigateur qui a déjà servi à un compte à privilèges — celui-ci
+      # évite le second aller-retour à l'agent qui revient.
+      # Jamais un paramètre de requête : c'est l'application qui décide du niveau exigé.
+      # Le cookie n'est pas signé : il ne peut qu'élever l'exigence, jamais l'abaisser,
+      # donc le forger ne donne rien. C'est CheckSecondFactor qui tranche, pas lui.
       def stepping_up?
-        session["proconnect_step_up"].present?
+        session["proconnect_step_up"].present? || request.cookies[PRIVILEGED_DEVICE_COOKIE].present?
       end
     end
   end

--- a/lib/portail/second_factor.rb
+++ b/lib/portail/second_factor.rb
@@ -1,0 +1,33 @@
+# frozen_string_literal: true
+
+module Portail
+  # Qui doit présenter un second facteur, et sa session l'a-t-elle fait. La règle ne peut pas
+  # vivre sur Membership : un modèle AR de `::` ne porte pas de logique d'un seul module.
+  module SecondFactor
+    # Parmi les niveaux qu'accepte déjà CheckAuthenticationLevel, ceux qui attestent un
+    # second facteur — `eidas1` seul est mono-facteur.
+    LEVELS = %w[eidas1-mfa eidas2 eidas3].freeze
+
+    module_function
+
+    def required_for?(membership)
+      membership.local_administrator? || sensitive_habilitation?(membership)
+    end
+
+    # N'a de sens que sur une session accordée : un refus n'a pas de rattachement, et
+    # l'appelant s'en assure.
+    def satisfied?(provider_session)
+      return true unless required_for?(provider_session.membership)
+
+      LEVELS.include?(provider_session.acr)
+    end
+
+    def sensitive_habilitation?(membership)
+      return false if SensitiveProcesses::CODES.empty?
+
+      membership.process_accesses
+        .where("UPPER(process_code) IN (?)", SensitiveProcesses::CODES)
+        .exists?
+    end
+  end
+end

--- a/lib/portail/second_factor.rb
+++ b/lib/portail/second_factor.rb
@@ -14,12 +14,10 @@ module Portail
       membership.local_administrator? || sensitive_habilitation?(membership)
     end
 
-    # N'a de sens que sur une session accordée : un refus n'a pas de rattachement, et
-    # l'appelant s'en assure.
-    def satisfied?(provider_session)
-      return true unless required_for?(provider_session.membership)
+    def satisfied?(membership, acr)
+      return true unless required_for?(membership)
 
-      LEVELS.include?(provider_session.acr)
+      LEVELS.include?(acr)
     end
 
     def sensitive_habilitation?(membership)

--- a/lib/portail/sensitive_processes.rb
+++ b/lib/portail/sensitive_processes.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Portail
+  # Les processus dont l'accès exige un second facteur. La liste n'est pas dans ce dépôt,
+  # qui est public : elle est injectée par l'environnement depuis ansible_deploy.
+  # Sa présence est exigée au démarrage par config/initializers/sensitive_processes.rb.
+  module SensitiveProcesses
+    module_function
+
+    # Majuscules des deux côtés de la comparaison : les codes sont stockés verbatim, et une
+    # divergence de casse ferait échapper un agent au second facteur en silence.
+    def parse(raw)
+      raw.to_s.split(",").map { |code| code.strip.upcase }.reject(&:empty?).freeze
+    end
+
+    # Déclarée après `parse`, qui la construit.
+    CODES = parse(ENV.fetch("SENSITIVE_PROCESS_CODES", ""))
+  end
+end

--- a/spec/controllers/portail/authentication_spec.rb
+++ b/spec/controllers/portail/authentication_spec.rb
@@ -86,6 +86,32 @@ RSpec.describe Portail::BaseController, type: :controller do
 
       expect { get :index }.not_to change { ProviderSession.last.updated_at }
     end
+
+    # Le second facteur se relit comme l'autorisation : un rattachement devenu à
+    # privilèges pendant la session ne doit pas la laisser se poursuivre.
+    it "closes a session whose membership became privileged mid-flight" do
+      provider_session = create(:provider_session,
+        membership: create(:membership, :local_administrator), acr: "eidas1")
+      session[:provider_session_id] = provider_session.id
+
+      get :index
+
+      # Vers l'élévation, pas vers l'accueil : l'agent éjecté doit savoir quoi faire, et
+      # le marqueur fait exiger la MFA dès la première autorisation suivante.
+      expect(response).to redirect_to(step_up_path)
+      expect(session[:provider_session_id]).to be_nil
+      expect(session[:proconnect_step_up]).to be(true)
+    end
+
+    it "leaves a privileged session alone once it carries a second factor" do
+      provider_session = create(:provider_session,
+        membership: create(:membership, :local_administrator), acr: "eidas1-mfa")
+      session[:provider_session_id] = provider_session.id
+
+      get :index
+
+      expect(response).to have_http_status(:ok)
+    end
   end
 
   describe ".allow_unauthenticated_access" do
@@ -99,6 +125,18 @@ RSpec.describe Portail::BaseController, type: :controller do
       expect(authentication_required?(Portail::DashboardController)).to be(false)
       expect(authentication_required?(Portail::ErrorsController)).to be(false)
       expect(authentication_required?(Portail::SessionsController)).to be(false)
+    end
+
+    def second_factor_enforced?(controller_class)
+      controller_class._process_action_callbacks.any? { |callback| callback.filter == :enforce_second_factor! }
+    end
+
+    # Entrer et sortir doit rester possible : un agent dont les droits viennent de changer
+    # se ferait sinon éjecter au moment où il essaie de se déconnecter, et sa session
+    # ProConnect resterait ouverte.
+    it "never gets between an agent and the sign-out path" do
+      expect(second_factor_enforced?(Portail::SessionsController)).to be(false)
+      expect(second_factor_enforced?(Portail::DashboardController)).to be(true)
     end
   end
 end

--- a/spec/interactors/portail/sessions/create/check_second_factor_spec.rb
+++ b/spec/interactors/portail/sessions/create/check_second_factor_spec.rb
@@ -1,0 +1,51 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Portail::Sessions::Create::CheckSecondFactor do
+  subject(:result) { described_class.call(membership:, claims: {acr:}, step_up_attempted:) }
+
+  let(:step_up_attempted) { nil }
+
+  context "when the membership owes no second factor" do
+    let(:membership) { create(:membership) }
+    let(:acr) { "eidas1" }
+
+    it "lets the session through" do
+      expect(result).to be_success
+    end
+  end
+
+  context "when the membership owes one" do
+    let(:membership) { create(:membership, :local_administrator) }
+
+    context "and the level attests it" do
+      let(:acr) { "eidas1-mfa" }
+
+      it "lets the session through" do
+        expect(result).to be_success
+      end
+    end
+
+    context "and the level does not" do
+      let(:acr) { "eidas1" }
+
+      # Première tentative : on élève plutôt que de refuser, ProConnect sachant fournir le
+      # second facteur même quand le fournisseur d'identité ne le sait pas.
+      it "asks for a step-up" do
+        expect(result).to be_failure
+        expect(result.error).to eq(:step_up_required)
+      end
+
+      context "after a step-up already went through" do
+        let(:step_up_attempted) { true }
+
+        # Redemander enverrait l'agent en boucle entre les deux services.
+        it "refuses instead of asking again" do
+          expect(result).to be_failure
+          expect(result.error).to eq(:second_factor_required)
+        end
+      end
+    end
+  end
+end

--- a/spec/lib/omni_auth/strategies/proconnect_hardened_spec.rb
+++ b/spec/lib/omni_auth/strategies/proconnect_hardened_spec.rb
@@ -22,6 +22,8 @@ RSpec.describe OmniAuth::Strategies::ProconnectHardened do
       expect(strategy).to receive(:store_new_state!).and_return("state-1")
       expect(strategy).to receive(:store_new_nonce!).and_return("nonce-1")
       expect(strategy).to receive(:session).at_least(:once).and_return({})
+      expect(strategy).to receive(:request).at_least(:once)
+        .and_return(instance_double(Rack::Request, cookies: {}))
 
       uri = strategy.send(:authorization_uri)
       params = Rack::Utils.parse_query(URI(uri).query)
@@ -38,6 +40,8 @@ RSpec.describe OmniAuth::Strategies::ProconnectHardened do
         .and_return("authorization_endpoint" => "https://proconnect.gouv.fr/api/v2/authorize")
       expect(strategy).to receive(:store_new_state!).and_return("state-1")
       expect(strategy).to receive(:store_new_nonce!).and_return("nonce-1")
+      # Pas de stub de `request` : le marqueur de session suffit, les cookies ne sont
+      # même pas consultés.
       expect(strategy).to receive(:session).at_least(:once)
         .and_return({"proconnect_step_up" => true})
 
@@ -47,6 +51,25 @@ RSpec.describe OmniAuth::Strategies::ProconnectHardened do
         {id_token: {amr: {essential: true},
                     acr: {essential: true, values: Portail::SecondFactor::LEVELS}}}.to_json
       )
+      # Laisser acr_values au plancher enverrait la consigne inverse dans la même requête.
+      expect(params["acr_values"]).to eq("eidas1-mfa eidas2 eidas3")
+    end
+
+    # Un navigateur déjà reconnu évite le second aller-retour : on exige dès la première
+    # autorisation, sans attendre de savoir qui arrive.
+    it "demands a second factor from the start on a remembered device" do
+      expect(strategy).to receive(:discovered_configuration)
+        .and_return("authorization_endpoint" => "https://proconnect.gouv.fr/api/v2/authorize")
+      expect(strategy).to receive(:store_new_state!).and_return("state-1")
+      expect(strategy).to receive(:store_new_nonce!).and_return("nonce-1")
+      expect(strategy).to receive(:session).at_least(:once).and_return({})
+      expect(strategy).to receive(:request).at_least(:once).and_return(
+        instance_double(Rack::Request, cookies: {described_class::PRIVILEGED_DEVICE_COOKIE => "1"})
+      )
+
+      params = Rack::Utils.parse_query(URI(strategy.send(:authorization_uri)).query)
+
+      expect(params["acr_values"]).to eq("eidas1-mfa eidas2 eidas3")
     end
   end
 

--- a/spec/lib/omni_auth/strategies/proconnect_hardened_spec.rb
+++ b/spec/lib/omni_auth/strategies/proconnect_hardened_spec.rb
@@ -21,6 +21,7 @@ RSpec.describe OmniAuth::Strategies::ProconnectHardened do
         .and_return("authorization_endpoint" => "https://proconnect.gouv.fr/api/v2/authorize")
       expect(strategy).to receive(:store_new_state!).and_return("state-1")
       expect(strategy).to receive(:store_new_nonce!).and_return("nonce-1")
+      expect(strategy).to receive(:session).at_least(:once).and_return({})
 
       uri = strategy.send(:authorization_uri)
       params = Rack::Utils.parse_query(URI(uri).query)
@@ -28,6 +29,24 @@ RSpec.describe OmniAuth::Strategies::ProconnectHardened do
       expect(params["claims"]).to eq({id_token: {amr: {essential: true}}}.to_json)
       expect(params["acr_values"]).to eq("eidas1")
       expect(params["scope"]).to eq("openid given_name usual_name email")
+    end
+
+    # L'élévation se demande par `claims`, pas par acr_values, qui n'annonce qu'un plancher
+    # et n'oblige à rien — cf. doc ProConnect « Forcer la double authentification ».
+    it "demands a second factor when the session is marked for a step-up" do
+      expect(strategy).to receive(:discovered_configuration)
+        .and_return("authorization_endpoint" => "https://proconnect.gouv.fr/api/v2/authorize")
+      expect(strategy).to receive(:store_new_state!).and_return("state-1")
+      expect(strategy).to receive(:store_new_nonce!).and_return("nonce-1")
+      expect(strategy).to receive(:session).at_least(:once)
+        .and_return({"proconnect_step_up" => true})
+
+      params = Rack::Utils.parse_query(URI(strategy.send(:authorization_uri)).query)
+
+      expect(params["claims"]).to eq(
+        {id_token: {amr: {essential: true},
+                    acr: {essential: true, values: Portail::SecondFactor::LEVELS}}}.to_json
+      )
     end
   end
 

--- a/spec/lib/portail/second_factor_spec.rb
+++ b/spec/lib/portail/second_factor_spec.rb
@@ -1,0 +1,54 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Portail::SecondFactor do
+  before { stub_const("Portail::SensitiveProcesses::CODES", %w[SGR]) }
+
+  def membership_with(process_code, *traits)
+    create(:membership, *traits).tap do |membership|
+      create(:process_access, membership:, process_code:) if process_code
+    end
+  end
+
+  describe ".required_for?" do
+    it "spares an ordinary agent who touches no sensitive process" do
+      expect(described_class.required_for?(membership_with(nil))).to be(false)
+      expect(described_class.required_for?(membership_with("AEC"))).to be(false)
+    end
+
+    it "requires it of a local administrator, whatever their processes" do
+      expect(described_class.required_for?(membership_with(nil, :local_administrator)))
+        .to be(true)
+    end
+
+    it "requires it of an ordinary agent holding a sensitive process" do
+      expect(described_class.required_for?(membership_with("SGR"))).to be(true)
+    end
+
+    # Les codes sont stockés verbatim : sans comparaison insensible à la casse, cet agent
+    # échapperait au second facteur sans qu'aucune erreur ne le signale.
+    it "requires it however the sensitive code is spelled" do
+      expect(described_class.required_for?(membership_with("sgr"))).to be(true)
+    end
+  end
+
+  describe ".satisfied?" do
+    it "lets any level through for a membership that owes no second factor" do
+      session = create(:provider_session, membership: membership_with(nil), acr: "eidas1")
+
+      expect(described_class.satisfied?(session)).to be(true)
+    end
+
+    it "accepts only the levels that attest a second factor" do
+      membership = membership_with(nil, :local_administrator)
+
+      expect(described_class.satisfied?(create(:provider_session, membership:, acr: "eidas1")))
+        .to be(false)
+      expect(described_class.satisfied?(create(:provider_session, membership:, acr: "eidas1-mfa")))
+        .to be(true)
+      expect(described_class.satisfied?(create(:provider_session, membership:, acr: "eidas2")))
+        .to be(true)
+    end
+  end
+end

--- a/spec/lib/portail/second_factor_spec.rb
+++ b/spec/lib/portail/second_factor_spec.rb
@@ -35,20 +35,15 @@ RSpec.describe Portail::SecondFactor do
 
   describe ".satisfied?" do
     it "lets any level through for a membership that owes no second factor" do
-      session = create(:provider_session, membership: membership_with(nil), acr: "eidas1")
-
-      expect(described_class.satisfied?(session)).to be(true)
+      expect(described_class.satisfied?(membership_with(nil), "eidas1")).to be(true)
     end
 
     it "accepts only the levels that attest a second factor" do
       membership = membership_with(nil, :local_administrator)
 
-      expect(described_class.satisfied?(create(:provider_session, membership:, acr: "eidas1")))
-        .to be(false)
-      expect(described_class.satisfied?(create(:provider_session, membership:, acr: "eidas1-mfa")))
-        .to be(true)
-      expect(described_class.satisfied?(create(:provider_session, membership:, acr: "eidas2")))
-        .to be(true)
+      expect(described_class.satisfied?(membership, "eidas1")).to be(false)
+      expect(described_class.satisfied?(membership, "eidas1-mfa")).to be(true)
+      expect(described_class.satisfied?(membership, "eidas2")).to be(true)
     end
   end
 end

--- a/spec/lib/portail/sensitive_processes_spec.rb
+++ b/spec/lib/portail/sensitive_processes_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Portail::SensitiveProcesses do
+  describe ".parse" do
+    it "reads a comma separated list, whatever the spacing and the case" do
+      expect(described_class.parse("SGR,dsg , Gro")).to eq(%w[SGR DSG GRO])
+    end
+
+    # Une liste vide est un choix légitime : plus aucun processus n'est sensible.
+    it "accepts an empty list" do
+      expect(described_class.parse("")).to eq([])
+      expect(described_class.parse(" , ")).to eq([])
+    end
+  end
+
+  describe "CODES" do
+    it "is frozen so no caller can widen the rule at runtime" do
+      expect(described_class::CODES).to be_frozen
+    end
+  end
+end

--- a/spec/requests/portail/sessions_spec.rb
+++ b/spec/requests/portail/sessions_spec.rb
@@ -448,6 +448,18 @@ RSpec.describe "Portail::Sessions", type: :request do
       expect(ProviderSession.last.denial_reason).to eq("second_factor_required")
     end
 
+    # Un rattachement rétrogradé doit cesser de marquer le navigateur : sinon celui-ci
+    # réclamerait la MFA pour toujours, et l'agent ne reverrait jamais la case pour la
+    # décocher — la page d'élévation n'ayant plus lieu d'apparaître.
+    it "forgets a device once its agent no longer owes a second factor" do
+      cookie = OmniAuth::Strategies::ProconnectHardened::PRIVILEGED_DEVICE_COOKIE
+      cookies[cookie] = "1"
+
+      sign_in_via_proconnect(agent: create(:agent), acr: "eidas1")
+
+      expect(cookies[cookie]).to be_blank
+    end
+
     it "never raises the requirement for an ordinary agent" do
       agent = create(:agent)
 

--- a/spec/requests/portail/sessions_spec.rb
+++ b/spec/requests/portail/sessions_spec.rb
@@ -381,4 +381,80 @@ RSpec.describe "Portail::Sessions", type: :request do
       expect(response).to redirect_to(auth_failure_path)
     end
   end
+
+  describe "second factor" do
+    def administrator_agent
+      create(:agent).tap do |agent|
+        link = OrganizationLink.find_or_create_by!(siret: ProConnectTestHelper::TEST_SIRET)
+        create(:membership, :local_administrator, agent:, organization_link: link)
+      end
+    end
+
+    # L'agent ne clique sur rien : la page porte un formulaire auto-soumis vers ProConnect.
+    it "sends a single-factor administrator back to ProConnect for a second factor" do
+      agent = administrator_agent
+
+      mock_proconnect(sub: agent.provider_sub, email: agent.email, acr: "eidas1")
+      get "/auth/proconnect/callback"
+
+      expect(response).to redirect_to(step_up_path)
+      expect(session[:proconnect_step_up]).to be(true)
+    end
+
+    # Le callback porte un code à usage unique : rendre l'élévation à son adresse la
+    # rendrait irrechargeable, et ProConnect répondrait 400 en rejouant le code.
+    it "serves the step-up page from its own address, and only when one is due" do
+      agent = administrator_agent
+      mock_proconnect(sub: agent.provider_sub, email: agent.email, acr: "eidas1")
+      get "/auth/proconnect/callback"
+
+      get step_up_path
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include("/auth/proconnect")
+
+      # Rechargeable, contrairement au callback.
+      get step_up_path
+      expect(response).to have_http_status(:ok)
+    end
+
+    it "turns away a visitor who lands on the step-up page with nothing to raise" do
+      get step_up_path
+
+      expect(response).to redirect_to(root_path)
+    end
+
+    it "lets the administrator in once the second factor is presented" do
+      agent = administrator_agent
+
+      mock_proconnect(sub: agent.provider_sub, email: agent.email, acr: "eidas1")
+      get "/auth/proconnect/callback"
+      mock_proconnect(sub: agent.provider_sub, email: agent.email, acr: "eidas1-mfa")
+      get "/auth/proconnect/callback"
+
+      expect(response).to redirect_to(root_path)
+      expect(ProviderSession.last).to be_granted
+    end
+
+    # Une seule élévation : ProConnect n'ayant pas relevé le niveau, redemander bouclerait.
+    it "refuses when the step-up came back at the same level" do
+      agent = administrator_agent
+
+      mock_proconnect(sub: agent.provider_sub, email: agent.email, acr: "eidas1")
+      get "/auth/proconnect/callback"
+      mock_proconnect(sub: agent.provider_sub, email: agent.email, acr: "eidas1")
+      get "/auth/proconnect/callback"
+
+      expect(response).to redirect_to(denied_path)
+      expect(ProviderSession.last.denial_reason).to eq("second_factor_required")
+    end
+
+    it "never raises the requirement for an ordinary agent" do
+      agent = create(:agent)
+
+      sign_in_via_proconnect(agent:, acr: "eidas1")
+
+      expect(response).to redirect_to(root_path)
+      expect(session[:proconnect_step_up]).to be_nil
+    end
+  end
 end


### PR DESCRIPTION
## Ce que fait cette PR

Un administrateur local peut ouvrir l'accès au portail à qui il veut dans son organisation. Ce pouvoir n'était protégé que par le facteur d'authentification de son fournisseur d'identité — souvent un simple mot de passe. Cette branche exige un second facteur des comptes à privilèges, et vérifie qu'il a réellement été présenté.

**La règle reprend celle de la V1**, en la simplifiant : administrateur local, **ou** agent habilité sur un processus sensible. `admin-portal` l'applique déjà au provisionnement Keycloak (`Keycloak::UserClient#otp_required?`) ; sa garde `user_type == "AGT"` n'a plus d'objet, un administrateur déclenchant déjà la première branche.

HubEE ne gère aucun second facteur en propre. ProConnect s'en charge, y compris l'enrôlement, et jusqu'à ce que les fournisseurs d'identité soient conformes il relaie lui-même par un code courriel (`eidas1-mfa`). C'est ce qui rend l'invariant « aucune exception » tenable sans rien développer de ce côté.

### Deux dimensions dans le même claim

`CheckAuthenticationLevel` gate déjà sur `acr`, mais sur le **lien organisationnel** : `eidas0-mfa` a bien un second facteur et reste déclaratif, donc refusé. Le second facteur est une dimension distincte, et sa liste est exactement les niveaux déjà acceptés moins `eidas1` :

```
ACCEPTED_LEVELS  eidas1  eidas1-mfa  eidas2  eidas3     lien organisationnel suffisant
LEVELS                   eidas1-mfa  eidas2  eidas3     second facteur présent
```

`eidas2` et `eidas3` n'ont pas de suffixe `-mfa` parce que la MFA forte y est **constitutive** du niveau. Durcir consistera à retirer `eidas1-mfa` — une valeur dans une liste.

### Petit piège

Tant que la demande d'élévation portait `acr_values=eidas1` (notre plancher) **à côté** du `claims` durci, ProConnect ignorait l'exigence **en silence** — ni élévation, ni erreur, malgré `essential: true`. Les deux paramètres se contredisaient et le plancher l'emportait. Il faut élever les deux conjointement. La documentation ProConnect ne mentionne pas cette interaction ; c'est signalé.

## Le dilemme d'expérience, et le choix fait

**La contrainte** : on ne sait pas qui est l'agent avant de l'avoir authentifié. Impossible, donc, d'exiger la MFA dès la première demande — la décision se prend au retour du callback. Il faut une seconde autorisation, et c'est là que ProConnect **réidentifie l'agent** : il lui redemande son adresse avant le code, dix secondes après qu'il l'a saisie.

Deux options, aucune satisfaisante.

**Option 1 — page d'explication puis élévation.** *(retenue)* L'agent revient sur HubEE, une page lui dit pourquoi il repart vers ProConnect et le prévient que son adresse lui sera redemandée. Un cookie, posé sur consentement, lui évite cet aller-retour aux connexions suivantes sur ce navigateur.

**Option 2 — formulaire d'adresse en amont.** L'agent saisit son adresse sur HubEE, on sait alors qui arrive et on exige la MFA dès la première autorisation. Écartée pour deux raisons. D'abord, elle **n'enlève pas l'écran** : ProConnect redemande l'adresse de toute façon. Ensuite et surtout, elle crée un **oracle** : décider avant d'authentifier rend la décision lisible dans l'URL de redirection, et n'importe qui apprendrait, sans s'authentifier, qu'une adresse correspond à un agent HubEE — et qu'il est à privilèges.

**Ce qui changerait tout** serait de pouvoir sauter l'écran d'adresse sur une session déjà ouverte. Aucun paramètre documenté ne le permet : `login_hint` pré-remplit seulement, `id_token_hint` n'est pas accepté sur l'`authorize`, et `prompt` est tout ou rien. La question est posée à ProConnect ; si leur réponse est « c'est un défaut », le cookie perd sa raison d'être et se retire.

### Le cookie, et ce qu'il coûte

Il ne porte **aucune identité** — un booléen, « ce navigateur a servi à un compte à privilèges » — et n'est **pas signé** : il ne peut qu'**élever** l'exigence, jamais l'abaisser, donc le forger ne rapporte rien. C'est `CheckSecondFactor` qui tranche après le retour, pas lui.

Sa contrepartie est le **poste partagé** : il vaut pour le navigateur, pas pour la personne. D'où une case **pré-cochée** dont le libellé nomme le cas où il faut la décocher, et un effacement automatique dès qu'une connexion n'exige plus de second facteur — sans quoi un rattachement rétrogradé réclamerait la MFA à vie, l'agent ne revoyant jamais la case.

### La page rendue au callback n'était pas rechargeable

Premier essai : la page d'élévation était rendue **à l'adresse du callback**. La recharger rejouait le code à usage unique, et ProConnect répondait 400. C'est l'erreur que #116 avait déjà corrigée pour la page de refus ; l'élévation a désormais la sienne, `/connexion/second-facteur`.

Et l'auto-soumission du formulaire, essayée d'abord pour épargner un clic, s'est révélée nuisible : la page passait en un éclair et l'agent se retrouvait devant ProConnect **sans savoir pourquoi**. Le clic qu'on voulait lui épargner était le seul moment où il pouvait comprendre.

## Ce qui se relit à chaque requête

Le second facteur n'est pas porté par le cookie de session : il est **recalculé à chaque requête**, comme l'autorisation l'est depuis #116. Un rattachement promu en cours de session ne laisse pas la session se poursuivre — l'agent est éjecté, et renvoyé sur la page d'élévation plutôt que sur un accueil muet.

Le contrôleur de sessions s'exonère de ce garde : un agent dont les droits viennent de changer doit pouvoir **se déconnecter**, et fermer aussi sa session ProConnect.

## Notes de déploiement

**Une variable est requise**, sans quoi l'application refuse de démarrer :

```
SENSITIVE_PROCESS_CODES
```

Les codes se recopient depuis `Keycloak::UserClient::SENSITIVE_PROCESSES` d'`admin-portal` vers **`ansible_deploy`**. Ils ne figurent nulle part dans ce dépôt, qui est public : les y écrire publierait un fragment du référentiel V1 et désignerait les processus que l'État tient pour les plus sensibles. `ansible_deploy` étant un dépôt GitLab, la liste reste privée **et** versionnée, relue en MR.

Déclarée mais **vide** est un choix légitime — plus aucun processus n'est sensible. **Absente** fait échouer le démarrage : sans cette distinction, une variable oubliée en recette produirait exactement le même comportement qu'une décision assumée, et rien ne le dirait.

La limite du callback passe de 10 par 3 minutes à **10 par minute** : un compte à privilèges consomme désormais deux passages par connexion.

## Points à trancher en équipe

Aucun ne bloque cette branche.

1. **Deux listes de processus sensibles cohabitent** pendant la transition — celle d'`admin-portal`, qui alimente le provisionnement Keycloak, et la nôtre, qui décide au runtime. Même contenu, natures différentes, et la première est condamnée avec #618. Une modification faite d'un seul côté laisserait la même personne protégée dans un portail et pas dans l'autre, **sans erreur visible**. À inscrire explicitement dans #618 : supprimer `SENSITIVE_PROCESSES` d'`admin-portal` avec l'OTP Keycloak.

2. **Le rate limit reste compté par IP.** Une administration derrière une seule sortie partage les 10 connexions par minute. Cette PR desserre, elle ne résout pas — la réserve de #116 reste entière.

3. **Le cookie de mémorisation** : pré-coché, donc opt-out. C'est un arbitrage entre le confort de l'administrateur et le risque qu'un poste partagé pousse des agents ordinaires vers un enrôlement dont ils n'ont pas besoin. L'effacement automatique limite la casse, il ne l'annule pas.

## Vérifications

`bin/ci` verte : **334 exemples, 0 échec**, Brakeman 0, couverture 97,6 %.

**Éprouvé à la main** sur l'environnement d'intégration ProConnect : l'élévation d'une session déjà ouverte fonctionne — c'était l'hypothèse qui conditionnait tout le design — pour un administrateur local comme pour un agent habilité sur un processus sensible ; le cookie évite bien le second aller-retour à la connexion suivante.

**Reste à éprouver** : la déconnexion d'un agent promu en cours de session, le refus après une élévation infructueuse, et le parcours d'un agent ordinaire, qui ne doit jamais voir la page d'élévation.

## Refs

- Ticket #619 — *Les comptes à privilèges ne sont protégés que par un seul facteur*
- Dépend du ticket #650, livré — le rôle porté par le rattachement et les habilitations aux processus
- Le retrait de `SENSITIVE_PROCESSES` d'`admin-portal` appartient à #618
