### PR TITLE
chore(deps): mettre à jour brakeman vers 8.0.6

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,7 +96,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.25.0)
       msgpack (~> 1.5)
-    brakeman (8.0.5)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     bundler-audit (0.9.3)


### PR DESCRIPTION
Version de correctif de l'analyseur statique de sécurité. Scan rejoué sur la base : 12 controllers, 13 modèles, 15 templates, 0 warning.